### PR TITLE
Improve ngdoc for params and returns.

### DIFF
--- a/lib/services.template
+++ b/lib/services.template
@@ -68,44 +68,75 @@ action.description =  '<em>\n' +
 } -%>
          * <%-: action.description | replace:/\n/g, '\n         * ' %>
          *
+<%
+var params = action.accepts;
+var postData;
+if (action.getHttpMethod() == 'POST' || action.getHttpMethod() == 'PUT') {
+  params = params.filter(function(arg) {
+    return arg.http && (arg.http.source == 'query' || arg.http.source == 'path');
+  });
+  postData = action.accepts.filter(function(arg) {
+    return params.indexOf(arg) == -1;
+  });
+}
+-%>
          * @param {Object=} parameters Request parameters.
-<% if (action.getHttpMethod() == 'POST' || action.getHttpMethod() == 'PUT') { -%>
+<% if (params.length == 0) { -%>
+         *
+         *   This method does not accept any parameters.
+         *   Supply an empty object or omit this argument altogether.
+<% } else { params.forEach(function(arg) { -%>
+         *
+         *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
+(arg.description || '').replace(/\n/g, '\n         *   ') %>
+<%   }); } -%>
+<% if (postData) { -%>
          *
          * @param {Object} postData Request data.
-<% } -%>
-<% if (!action.accepts || action.accepts.length == 0) { -%>
-         * This method does not accept any parameters. Supply an empty object.
-<% } else if (action.acceptsSingleBodyArgument(action.accepts)) { -%>
+<% if (postData.length == 0) { -%>
+         *
+         * This method does not accept any data. Supply an empty object.
+<% } else if (postData.length == 1 && postData[0].http &&
+      postData[0].http.source == 'body') { -%>
+         *
          * This method expects a subset of model properties as request parameters.
-<% } else { -%>
+<% } else {
+postData.forEach(function(arg) { -%>
          *
-         * Object properties:
-<%   action.accepts.forEach(function(arg) { -%>
-         *
-         * - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
+         *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
 (arg.description || '').replace(/\n/g, '\n         *   ') %>
 <%   });
-   }
--%>
+  }
+} -%>
          *
-<% var returnType = action.isReturningArray() ? 'Array.<Object>': 'Object'; %>
+<% var returnType = action.isReturningArray() ? 'Array.<Object>': 'Object'; -%>
          * @param {Function(<%- returnType %>, Object)=} successCb
-         *    Success callback with two arguments: `value`, `responseHeaders`.
+         *   Success callback with two arguments: `value`, `responseHeaders`.
          *
          * @param {Function(Object)=} errorCb Error callback with one argument:
-         *    `httpResponse`.
+         *   `httpResponse`.
          *
          * @return {<%- returnType %>} An empty reference that will be
          *   populated with the actual data once the response is returned
          *   from the server.
+         *
 <% if (!action.returns || action.returns.length == 0) { -%>
          * This method returns no data.
-<% } else if (!action.returns[0].root) { -%>
-         *
+<% } else if (action.returns[0].root) { -%>
+<%   if (action.returns[0].description) { -%>
+         * <%- action.returns[0].description
+.replace(/\n/g, '\n         * ').trimRight() %>
+<%   } else { -%>
+         * <em>
+         * (The remote method definition does not provide any description.
+         * This usually means the response is a `<%- modelName %>` object.)
+         * </em>
+<%   } -%>
+<% } else { -%>
          * Data properties:
 <%   action.returns.forEach(function(arg) { -%>
          *
-         * - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
+         *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
 (arg.description || '').replace(/\n/g, '\n         *   ') %>
 <%   });
    }


### PR DESCRIPTION
Split `accepts` arguments into `parameters` and `postData` for POST/PUT requests.

When `returns` is a single root argument, include its description in the `@return` comment.

Fix indentation where it was not consistent and/or caused different markdown output than intended.

These changes should improve the documentation of `User.login`, especially after strongloop/loopback#163.

/to @ritch please review.

The diffs of the code-gen template are rather difficult to read. Suggestions on how to make the template easier to read are very welcome.
