### PR TITLE
Extract test parsers

### DIFF
--- a/test/helpers/parse.js
+++ b/test/helpers/parse.js
@@ -1,0 +1,19 @@
+var expect = require('chai').expect;
+
+function parse(script, regex) {
+  expect(script).to.match(regex);
+  return regex.exec(script)[1] || '';
+}
+
+/*!
+ * Note: the functions below are used by grunt-loopback-angular tests
+ * and should be considered as part of the public API.
+ */
+
+exports.moduleName = function(script) {
+  return parse(script, /.*angular\.module\("([^"]*)",.*/);
+};
+
+exports.baseUrl = function(script) {
+  return parse(script, /var urlBase = "([^"]*)";/);
+}

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -5,6 +5,7 @@ var Promise = require('bluebird');
 var execFile = Promise.promisify(require('child_process').execFile);
 var expect = require('chai').expect;
 var debug = require('debug')('test');
+var parse = require('./helpers/parse');
 
 describe('lb-ng', function() {
   var sampleAppJs = require.resolve('./fixtures/app.js');
@@ -28,23 +29,23 @@ describe('lb-ng', function() {
       return runLbNg(sampleAppJs)
         .spread(function(script, stderr) {
           // the value "lbServices" is the --module-name default
-          expect(parseModuleName(script)).to.equal('lbServices');
+          expect(parse.moduleName(script)).to.equal('lbServices');
           // the value "/rest-api-root" is hard-coded in sampleAppJs
-          expect(parseBaseUrl(script)).to.equal('/rest-api-root');
+          expect(parse.baseUrl(script)).to.equal('/rest-api-root');
         });
     });
 
   it('uses the module name from command-line', function() {
     return runLbNg('-m', 'a-module-name', sampleAppJs)
       .spread(function(script, stderr) {
-        expect(parseModuleName(script)).to.equal('a-module-name');
+        expect(parse.moduleName(script)).to.equal('a-module-name');
       });
   });
 
   it('uses the url from command-line', function() {
     return runLbNg('-u', 'http://foo/bar', sampleAppJs)
       .spread(function(script, stderr) {
-        expect(parseBaseUrl(script)).to.equal('http://foo/bar');
+        expect(parse.baseUrl(script)).to.equal('http://foo/bar');
       });
   });
 
@@ -53,7 +54,7 @@ describe('lb-ng', function() {
     return runLbNg('-m', 'a-module', sampleAppJs, outfile)
       .spread(function(stdout, stderr) {
         var script = fs.readFileSync(outfile);
-        expect(parseModuleName(script)).to.equal('a-module');
+        expect(parse.moduleName(script)).to.equal('a-module');
         expect(stdout).to.equal('');
       });
   });
@@ -73,19 +74,6 @@ describe('lb-ng', function() {
         debug('--FAILED--\n%s--END--', err.cause.stack);
         throw err.cause;
       });
-  }
-
-  function parse(script, regex) {
-    expect(script).to.match(regex);
-    return regex.exec(script)[1] || '';
-  }
-
-  function parseModuleName(script) {
-    return parse(script, /.*angular\.module\("([^"]*)",.*/);
-  }
-
-  function parseBaseUrl(script) {
-    return parse(script, /var urlBase = "([^"]*)";/);
   }
 
   function resetSandbox() {


### PR DESCRIPTION
Extract methods used by unit-tests to parse the generated services
script, so that they can be used by grunt-loopback-angular too.

/to: @ritch please review
