### PR TITLE
Add User.getCurrent, persist accessTokenId in window.localStorage

### DIFF
--- a/lib/services.template
+++ b/lib/services.template
@@ -90,6 +90,12 @@ if (action.getHttpMethod() == 'POST' || action.getHttpMethod() == 'PUT') {
          *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
 (arg.description || '').replace(/\n/g, '\n         *   ') %>
 <%   }); } -%>
+<% if (modelName === 'User' && methodName === 'login') { -%>
+         *
+         *  - `rememberMe` - `boolean` - Whether the authentication credentials
+         *     should be remembered in localStorage across app/browser restarts.
+         *     Default: `true`.
+<% } -%>
 <% if (postData) { -%>
          *
          * @param {Object} postData Request data.
@@ -154,6 +160,8 @@ postData.forEach(function(arg) { -%>
               var accessToken = response.data;
               LoopBackAuth.currentUserId = accessToken.userId;
               LoopBackAuth.accessTokenId = accessToken.id;
+              LoopBackAuth.rememberMe = response.config.params.rememberMe !== false;
+              LoopBackAuth.save();
               return response.resource;
             }
           }
@@ -162,6 +170,7 @@ postData.forEach(function(arg) { -%>
             response: function(response) {
               LoopBackAuth.currentUserId = null;
               LoopBackAuth.accessTokenId = null;
+              LoopBackAuth.save();
               return response.resource;
             }
           }
@@ -209,22 +218,35 @@ postData.forEach(function(arg) { -%>
 
 module
   .factory('LoopBackAuth', function() {
-    var instance = {};
-    definePersistedProperty(instance, 'accessTokenId');
-    definePersistedProperty(instance, 'currentUserId');
-    return instance;
+    var props = ['accessTokenId', 'currentUserId'];
 
-    function definePersistedProperty(obj, propName) {
-      var key = '$LoopBack$' + propName;
-      Object.defineProperty(obj, propName, {
-        // Note: LocalStorage converts the value to string
-        // We are using empty string as a marker for null/undefined values.
-        get: function() { return localStorage[key] || null; },
-        set: function(value) {
-          if (value == null) value = '';
-          localStorage[key] = value;
-        }
-      });
+    function LoopBackAuth() {
+      props.forEach(function(name) {
+        this[name] = load(name);
+      }.bind(this));
+      this.rememberMe = undefined;
+    }
+
+    LoopBackAuth.prototype.save = function() {
+      var storage = this.rememberMe ? localStorage : sessionStorage;
+      props.forEach(function(name) {
+        save(storage, name, this[name]);
+      }.bind(this));
+    };
+
+    return new LoopBackAuth();
+
+    // Note: LocalStorage converts the value to string
+    // We are using empty string as a marker for null/undefined values.
+    function save(storage, name, value) {
+      var key = '$LoopBack$' + name;
+      if (value == null) value = '';
+      storage[key] = value;
+    }
+
+    function load(name) {
+      var key = '$LoopBack$' + name;
+      return localStorage[key] || sessionStorage[key] || null;
     }
   })
   .config(function($httpProvider) {

--- a/test.e2e/given.js
+++ b/test.e2e/given.js
@@ -59,14 +59,16 @@ define(['angular', 'angularMocks', 'angularResource'], function(angular) {
       .then(function(config) { return config.servicesUrl; })
       .then(injectScriptAtUrl)
       .then(function() {
-        var injector = angular.injector(['ng', 'ngMockE2E', options.name]);
-        // Setup the mocked http provider to pass all $http requests
-        // to our LoopBack server
-        var $httpBackend = injector.get('$httpBackend');
-        ['GET', 'POST', 'PUT', 'DELETE', 'HEAD'].forEach(function(method) {
-          $httpBackend.when(method).passThrough();
-        });
-        return injector;
+        return function createTestInjector() {
+          var injector = angular.injector(['ng', 'ngMockE2E', options.name]);
+          // Setup the mocked http provider to pass all $http requests
+          // to our LoopBack server
+          var $httpBackend = injector.get('$httpBackend');
+          ['GET', 'POST', 'PUT', 'DELETE', 'HEAD'].forEach(function(method) {
+            $httpBackend.when(method).passThrough();
+          });
+          return injector;
+        };
       });
 
     if (cb)

--- a/test.e2e/util.js
+++ b/test.e2e/util.js
@@ -12,7 +12,7 @@ define(function() {
       msg += ' ' + res.data.error.message;
     msg += ' [' + res.config.method + ' ' +res.config.url + ']';
 
-    var details = res.data.error.details;
+    var details = res.data && res.data.error && res.data.error.details;
     if (details)
       msg += '\nDetails: ' + JSON.stringify(details, null, 2);
 


### PR DESCRIPTION
The first commit is an unrelated cleanup, the second commit is the meat of this PR.

An example of usage can be found in loopback-example-access control (see strongloop/loopback-example-access-control@ba80d5e3a).
1. In the Angular app config, we can install `$http` interceptor to handle 401 responses by redirecting to `/login` view:
   
   ``` js
   // Intercept 401 responses and redirect to login screen
   $httpProvider.interceptors.push(function($q, $location, $rootScope) {
     return {
       responseError: function(rejection) {
         if (rejection.status == 401) {
           // save the current location so that login can redirect back
           $rootScope.nextAfterLogin = $location.path();
           $location.path('/login');
         }
         return $q.reject(rejection);
       }
     };
   });
   ```
2. The `login` action should redirect to the location saved by the code above:
   
   ``` js
     $scope.loginResult = User.login($scope.credentials,
       function() {
         var next = $rootScope.nextAfterLogin || '/';
         $rootScope.nextAfterLogin = null;
         $location.path(next);
       },
       function(res) {
         $scope.loginError = res.data.error;
       }
     );
   ```
3. The get data of the current user, the application has to call `User.getCurrent(success, error)`.  The application does not need to keep track of the current user id, as it is already tracked by LoopBack. It also does not need to check whether there is a user logged in or not - LoopBack will handle the latter case by returning a stub 401 response.
   
   ``` js
   $scope.currentUser =
   $rootScope.currentUser = User.getCurrent(function() {
     // success
   }, function(response) {
     console.log('User.getCurrent() err', arguments);
   });
   ```

This patch closes #9.

/to @Schoonology please review
/cc @ritch @seanbrookes 
