### PR TITLE
Add $rootScope.$currentUser and $rootScope.$ensureCurrentUser()

### DIFF
--- a/lib/services.template
+++ b/lib/services.template
@@ -14,11 +14,17 @@ var urlBase = <%-: urlBase | q %>;
  */
 var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
 
-<% for (var modelName in models) {
-     var meta = models[modelName];
+<%
+var hasUserModel = false;
 
-     // capitalize the model name
-     modelName = modelName[0].toUpperCase() + modelName.slice(1);
+for (var modelName in models) {
+  var meta = models[modelName];
+
+  // capitalize the model name
+  modelName = modelName[0].toUpperCase() + modelName.slice(1);
+
+  if (modelName === 'User') hasUserModel = true;
+
 -%>
 /**
  * @ngdoc object
@@ -42,8 +48,10 @@ var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
  */
 module.factory(
   <%-: modelName | q %>,
-  ['LoopBackResource', 'LoopBackAuth', function(Resource, LoopBackAuth) {
-    return Resource(
+  ['LoopBackResource', 'LoopBackAuth', '$q', '$rootScope',
+  function(Resource, LoopBackAuth, $q, $rootScope) {
+    var Model;
+    return Model = Resource(
       urlBase + <%-: meta.ctor.getFullPath() | q %>,
 <% /*
         Constructor arguments are hardcoded for now.
@@ -168,7 +176,23 @@ postData.forEach(function(arg) { -%>
               LoopBackAuth.accessTokenId = accessToken.id;
               LoopBackAuth.rememberMe = response.config.params.rememberMe !== false;
               LoopBackAuth.save();
+              $rootScope.$currentUser = createUserResource(accessToken.user);
               return response.resource;
+
+              function createUserResource(data) {
+                if (!data) return null;
+
+                var user = new Model(data);
+                user.$resolved = true;
+
+                // Create a resolved promise to mirror the behaviour
+                // of $resource HTTP calls
+                var deferred = $q.defer();
+                deferred.resolve(user);
+                user.$promise = deferred.promise;
+
+                return user;
+              }
             }
           }
 <% } else if (modelName === 'User' && methodName === 'logout') { -%>
@@ -177,6 +201,7 @@ postData.forEach(function(arg) { -%>
               LoopBackAuth.currentUserId = null;
               LoopBackAuth.accessTokenId = null;
               LoopBackAuth.save();
+              $rootScope.$currentUser = null;
               return response.resource;
             }
           }
@@ -258,8 +283,8 @@ module
   .config(function($httpProvider) {
     $httpProvider.interceptors.push('LoopBackAuthRequestInterceptor');
   })
-  .factory('LoopBackAuthRequestInterceptor', [ '$q', 'LoopBackAuth',
-    function($q, LoopBackAuth) {
+  .factory('LoopBackAuthRequestInterceptor', [ '$q', '$rootScope', 'LoopBackAuth',
+    function($q, $rootScope, LoopBackAuth) {
       return {
         'request': function(config) {
           if (LoopBackAuth.accessTokenId) {
@@ -276,6 +301,14 @@ module
             return $q.reject(res);
           }
           return config || $q.when(config);
+<% if (hasUserModel) { -%>
+        },
+        'responseError': function(rejection) {
+          if (rejection.status == 401) {
+            $rootScope.$currentUser = null;
+          }
+          return $q.reject(rejection);
+<% } -%>
         }
       }
     }])
@@ -295,7 +328,66 @@ module
 
       return resource;
     };
-  }]);
+<% if (hasUserModel) { -%>
+  }])
+  .run(['$rootScope', 'User', function($rootScope, User) {
+    /**
+     * @ngdoc object
+     * @name ng.$rootScope
+     * @description
+     *
+     * LoopBack's extensions of `$rootScope` object.
+     */
+
+    /**
+     * @ngdoc property
+     * @name ng.$rootScope#$currentUser
+     * @propertyOf ng.$rootScope
+     *
+     * @description
+     *
+     * The {@link <%- moduleName %>.User `User`} resource of the user
+     * that is currently logged in, or `null`.
+     *
+     * You should always call
+     * {@link ng.$rootScope#$ensureCurrentUser `$rootScope.$ensureCurrentUser()`}
+     * before accessing this property.
+     *
+     */
+    $rootScope.$currentUser = null;
+
+    /**
+     * @ngdoc method
+     * @name ng.$rootScope#$ensureCurrentUser
+     * @methodOf ng.$rootScope
+     *
+     * @description
+     *
+     * This method ensures that
+     * {@link ng.$rootScope#$currentUser `$rootScope.$currentUser`} is set.
+     *
+     *  - When `$currentUser` is null,
+     *    {@link <%- moduleName %>.User#getCurrent `User.getCurrent()`}
+     *    is called to set it up.
+     *  - When there is no user logged in, `User.getCurrent()` will fail with
+     *    401 Unauthorized, which should trigger redirect to the login page in
+     *    most applications.
+     *  - When the value was already filled by a previous call
+     *    of `$ensureCurrentUser` or
+     *    {@link <%- moduleName %>.User#login `User.login`},
+     *    then the call is a no-op.
+     *
+     * @return {Promise} Promise that is resolved with the User resource once it
+     *   is available. The promise is usually the value of
+     *   `$rootScope.$currentUser.$promise`.
+     */
+    $rootScope.$ensureCurrentUser = function() {
+      if (!$rootScope.$currentUser)
+        $rootScope.$currentUser = User.getCurrent();
+      return $rootScope.$currentUser.$promise;
+    };
+<% } -%>
+  }])
 <%
 function getJsDocType(arg) {
   var type = arg.type == 'any' ? '*' : arg.type;


### PR DESCRIPTION
Make it easier to access data of the user that is currently logged in.

Before this change, developers had to add bits of code all over the application.

``` js
// Inside app run block
$rootScope.$on("$routeChangeStart", function(event, next, current) {
  if (!$rootScope.currentUser && $location.path() != '/login') {
    $rootScope.currentUser = User.getCurrent();
  }
});

// Inside app config block
$httpProvider.interceptors.push(function($q, $location, $rootScope) {
  return {
    responseError: function(rejection) {
      if (rejection.status == 401) {
        $rootScope.currentUser = null;
        // etc.
      }
      return $q.reject(rejection);
    }
  };
});

// In the login action
User.login({ include: 'user' }, $scope.credentials, function(result) {
  $rootScope.currentUser = new User(result.user);
  // etc.
});

// In the logout action
User.logout(function() {
  $rootScope.currentUser = null;
  // etc.
});
```

Once this patch is landed, working with the current user is super easy:

``` js
// Inside app run block
$rootScope.$on("$routeChangeStart", function(event, next, current) {
  if ($location.path != '/login')
    $rootScope.$ensureCurrentUser();
});

// use $rootScope.$currentUser instead of $rootScope.currentUser
```

/to @ritch or @Schoonology please review.
/cc @seanbrookes 
/cc @crandmck I'll update the docs after this patch is accepted.
