### PR TITLE
[WIP] Add AnuglarJS API docs for built-in models

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -2,3 +2,4 @@ bower_components/
 node_modules/
 coverage/
 karma.conf.js
+apidocs/lb-services.js

--- a/apidocs/.gitignore
+++ b/apidocs/.gitignore
@@ -1,0 +1,1 @@
+lb-services.js

--- a/apidocs/describe-builtin-models.js
+++ b/apidocs/describe-builtin-models.js
@@ -1,0 +1,36 @@
+var fs = require('fs');
+var path = require('path');
+var loopback = require('loopback');
+var generator = require('..');
+
+var app = loopback();
+
+app.dataSource('db', { connector: 'memory', defaultForType: 'db' });
+app.dataSource('mail', { connector: 'mail', defaultForType: 'mail' });
+
+app.model('User', {
+  options: {
+    base: 'User',
+    relations: {
+      accessTokens: {
+        model: 'AccessToken',
+        type: 'hasMany',
+        foreignKey: 'userId'
+      }
+    }
+  },
+  dataSource: 'db'
+});
+
+loopback.autoAttach();
+
+for (var key in loopback) {
+  model = loopback[key];
+  if (model.prototype instanceof loopback.Model && key != 'User') {
+    app.model(model);
+    console.log('added model %s', key);
+  }
+}
+
+var script = generator.services(app, 'lbServices', '/api');
+fs.writeFileSync(path.resolve(__dirname, 'lb-services.js'), script);

--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,8 @@
+{
+  "title": "LoopBack AngularJS API",
+  "content": [
+    { "title": "Built-in Models", "depth": 2 },
+    "apidocs/lb-services.js"
+  ],
+  "init": "node ./apidocs/describe-builtin-models.js"
+}


### PR DESCRIPTION
Add apidocs/describe-builtin-models.js - a script that sets
up a loopback app with all built-in models attached and generates
the AngularJS services for this app.

Add docs.json configured to run the new script and use the generated
services file as a source for strong-docs.

This is a work in progress, strong-docs does not parse ngdoc comments correctly at the moment.

/cc: @ritch @crandmck 
