### PR TITLE
Fix - Minification issue (angular dependency) and global object preservation

### DIFF
--- a/lib/services.template
+++ b/lib/services.template
@@ -1,4 +1,4 @@
-'use strict';
+(function(window, angular, undefined) {'use strict';
 
 var urlBase = <%-: urlBase | q %>;
 
@@ -183,9 +183,9 @@ module
       return localStorage[key] || sessionStorage[key] || null;
     }
   })
-  .config(function($httpProvider) {
+  .config(['$httpProvider', function($httpProvider) {
     $httpProvider.interceptors.push('LoopBackAuthRequestInterceptor');
-  })
+  }])
   .factory('LoopBackAuthRequestInterceptor', [ '$q', 'LoopBackAuth',
     function($q, LoopBackAuth) {
       return {
@@ -341,3 +341,5 @@ postData.forEach(function(arg) { -%>
 -%>
          */
 <% } // end of ngdocForMethod -%>
+
+})(window, window.angular);

--- a/test.e2e/test-server.js
+++ b/test.e2e/test-server.js
@@ -107,8 +107,8 @@ masterApp.post('/setup', function(req, res, next) {
       servicesScript = 'throw new Error("Error generating services script.");';
     }
 
-    servicesScript += '\nmodule.value("testData", ' +
-      JSON.stringify(data, null, 2) + ');\n';
+    servicesScript += '\nangular.module(' + JSON.stringify(name) + ')' +
+      '.value("testData", ' + JSON.stringify(data, null, 2) + ');\n';
 
     res.send(200, { servicesUrl: baseUrl + 'services?' + name });
   }.bind(this));


### PR DESCRIPTION
The `$httpProvider` dependency was not explicitly declared, which is why the module broke when minified.

Also, in the test server, I update `module` var to be fetched through `angular.module()`, so the main generated file can be isolated from global object.
