### PR TITLE
Move `bower install` to `postinstall` script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tool for auto-generating Angular $resource services for LoopBack",
   "main": "index.js",
   "scripts": {
-    "pretest": "jshint . ; bower install",
+    "pretest": "jshint . && bower install",
     "test": "node ./test.e2e/test-server.js node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
   },
   "repository": {


### PR DESCRIPTION
This way `npm test` runs faster on local machine and the `pretest`
script fails when there are any jshint errors.

/to @rmg please review
