### PR TITLE
Support remote method aliases

### DIFF
--- a/lib/services.template
+++ b/lib/services.template
@@ -130,6 +130,16 @@ module.factory(
     );
 
 
+<% meta.methods.forEach(function(action) {
+    var methodName = action.name.split('.').join('$');
+    (action.sharedMethod.aliases || []).forEach(function(alias) {
+      var aliasMethod = alias.split('.').join('$');
+
+      ngdocForMethod(modelName, aliasMethod, action); -%>
+        R[<%-: aliasMethod | q %>] = R[<%-: methodName | q %>];
+<%  }); // aliases.foreach
+  }); // meta.methods.foreach
+-%>
 
 <% if (modelName === 'User') { -%>
         /**

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -97,6 +97,25 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
             return found.$promise;
           });
       });
+
+      it('has all methods including aliases', function() {
+        var methodNames = Object.keys(MyModel);
+        console.log('methods', methodNames);
+        expect(methodNames).to.include.members([
+          'create',
+          'updateOrCreate',
+          'upsert',
+          'exists',
+          'findById',
+          'find',
+          'findOne',
+          'destroyById',
+          'deleteById',
+          'removeById',
+          'count',
+          'prototype$updateAttributes'
+        ]);
+      });
     });
 
     describe('$resource for model with funky name', function() {


### PR DESCRIPTION
The recent strong-remoting versions merge all `SharedMethod` entries of the same function into a single entry with `aliases` property holding alternate names. That caused the code-gen output to include only one the main name (e.g. `deleteById`) and omit aliases (e.g. `destroyById`).

This patch fixes the problem by creating resource methods for all aliases.

Close #51.

/to @ritch 
/cc @raymondfeng 
