### PR TITLE
Add configurable authentication header

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -1,6 +1,7 @@
 (function(window, angular, undefined) {'use strict';
 
 var urlBase = <%-: urlBase | q %>;
+var authHeader = 'authorization';
 
 /**
  * @ngdoc overview
@@ -303,7 +304,7 @@ module
       return {
         'request': function(config) {
           if (LoopBackAuth.accessTokenId) {
-            config.headers.authorization = LoopBackAuth.accessTokenId;
+            config.headers[authHeader] = LoopBackAuth.accessTokenId;
           } else if (config.__isGetCurrentUser__) {
             // Return a stub 401 error for User.getCurrent() when
             // there is no user logged in
@@ -319,23 +320,39 @@ module
         }
       }
     }])
-  .factory('LoopBackResource', [ '$resource', function($resource) {
-    return function(url, params, actions) {
-      var resource = $resource(url, params, actions);
 
-      // Angular always calls POST on $save()
-      // This hack is based on
-      // http://kirkbushell.me/angular-js-using-ng-resource-in-a-more-restful-manner/
-      resource.prototype.$save = function(success, error) {
-        // Fortunately, LoopBack provides a convenient `upsert` method
-        // that exactly fits our needs.
-        var result = resource.upsert.call(this, {}, this, success, error);
-        return result.$promise || result;
-      }
-
-      return resource;
+  /**
+   * @ngdoc provider
+   * @name <%-: moduleName %>.LoopBackResourceProvider
+   */
+  .provider('LoopBackResource', function LoopBackResourceProvider() {
+    /**
+     * @ngdoc method
+     * @name <%-: moduleName %>.LoopBackResourceProvider#setAuthHeader
+     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @param {string} header The header name to use, e.g. `X-Access-Token`
+     */
+    this.setAuthHeader = function(header) {
+      authHeader = header;
     };
-  }]);
+
+    this.$get = ['$resource', function($resource) {
+      return function(url, params, actions) {
+        var resource = $resource(url, params, actions);
+
+        // Angular always calls POST on $save()
+        // This hack is based on
+        // http://kirkbushell.me/angular-js-using-ng-resource-in-a-more-restful-manner/
+        resource.prototype.$save = function(success, error) {
+          // Fortunately, LoopBack provides a convenient `upsert` method
+          // that exactly fits our needs.
+          var result = resource.upsert.call(this, {}, this, success, error);
+          return result.$promise || result;
+        };
+        return resource;
+      };
+    }];
+  });
 <%
 function getJsDocType(arg) {
   var type = arg.type == 'any' ? '*' : arg.type;


### PR DESCRIPTION
LoopBackResource was changed from factory to provider to be able to
configure the service.

Add the `setAuthHeader` method to set the custom authentication header.

Follow-up for #65
