### PR TITLE
replaces "lbServices" in services.template.ejs with moduleName tag

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -89,8 +89,8 @@ module.factory(
 
         /**
          * @ngdoc method
-         * @name lbServices.<%- modelName %>#getCurrent
-         * @methodOf lbServices.<%- modelName %>
+         * @name <%- moduleName %>.<%- modelName %>#getCurrent
+         * @methodOf <%- moduleName %>.<%- modelName %>
          *
          * @description
          *
@@ -144,14 +144,14 @@ module.factory(
 <% if (meta.isUser) { -%>
         /**
          * @ngdoc method
-         * @name lbServices.<%- modelName %>#getCachedCurrent
-         * @methodOf lbServices.<%- modelName %>
+         * @name <%- moduleName %>.<%- modelName %>#getCachedCurrent
+         * @methodOf <%- moduleName %>.<%- modelName %>
          *
          * @description
          *
          * Get data of the currently logged user that was returned by the last
-         * call to {@link lbServices.<%- modelName %>#login} or
-         * {@link lbServices.<%- modelName %>#getCurrent}. Return null when there
+         * call to {@link <%- moduleName %>.<%- modelName %>#login} or
+         * {@link <%- moduleName %>.<%- modelName %>#getCurrent}. Return null when there
          * is no user logged in or the data of the current user were not fetched
          * yet.
          *
@@ -164,8 +164,8 @@ module.factory(
 
         /**
          * @ngdoc method
-         * @name lbServices.<%- modelName %>#isAuthenticated
-         * @methodOf lbServices.<%- modelName %>
+         * @name <%- moduleName %>.<%- modelName %>#isAuthenticated
+         * @methodOf <%- moduleName %>.<%- modelName %>
          *
          * @return {boolean} True if the current user is authenticated (logged in).
          */
@@ -175,8 +175,8 @@ module.factory(
 
         /**
          * @ngdoc method
-         * @name lbServices.<%- modelName %>#getCurrentId
-         * @methodOf lbServices.<%- modelName %>
+         * @name <%- moduleName %>.<%- modelName %>#getCurrentId
+         * @methodOf <%- moduleName %>.<%- modelName %>
          *
          * @return {Object} Id of the currently logged-in user or null.
          */


### PR DESCRIPTION
fixes #76 ( **services.template.ejs hardcodes "lbServices" instead of using moduleName tag** )
