### PR TITLE
Add `R.modelName` property

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -232,6 +232,16 @@ module.factory(
 <%    }); // forEach methods name -%>
 <% } // for each scope -%>
 
+    /**
+    * @ngdoc property
+    * @name <%- moduleName %>.<%- modelName %>#modelName
+    * @propertyOf <%- moduleName %>.<%- modelName %>
+    * @description
+    * The name of the model represented by this $resource,
+    * i.e. `<%- modelName %>`.
+    */
+    R.modelName = <%-: modelName | q %>;
+
     return R;
   }]);
 

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -116,6 +116,10 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
           'prototype$updateAttributes'
         ]);
       });
+
+      it('has `modelName` property', function() {
+        expect(MyModel).to.have.property('modelName', 'MyModel');
+      });
     });
 
     describe('$resource for model with funky name', function() {


### PR DESCRIPTION
When debugging code using loopback angular resource objects, it's
difficult to find out what kind of model is represented by
a given `$resource` object.

This commit adds `modelName` property to the resource constructor
to fix that issue.

/to @ritch please review
