### PR TITLE
Make urlBase configurable

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -336,6 +336,16 @@ module
       authHeader = header;
     };
 
+    /**
+     * @ngdoc method
+     * @name <%-: moduleName %>.LoopBackResourceProvider#setUrlBase
+     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @param {string} url
+     */
+    this.setUrlBase = function(url) {
+      urlBase = url;
+    };
+
     this.$get = ['$resource', function($resource) {
       return function(url, params, actions) {
         var resource = $resource(url, params, actions);


### PR DESCRIPTION
Add `setUrlBase` method to LoopBackResourceProvider to allow urlBase configuration.

Signed-off-by: Ariel Schiavoni arielschiavoni@gmail.com
