### PR TITLE
Allow exposing constants

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -15,6 +15,22 @@ var authHeader = 'authorization';
  */
 var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
 
+/**
+ * @ngdoc object
+ * @name <%- moduleName %>.<%- moduleName  %>_CONSTANTS
+ * @object
+ *
+ * @description
+ *
+ * A service which exposes some of the constants used by this API
+ * like urlBase and authHeader.
+ *
+ */
+module.constant(<%-: moduleName | q %> + '_CONSTANTS', {
+  'urlBase': urlBase,
+  'authHeader': authHeader
+});
+
 <% for (var modelName in models) {
      var meta = models[modelName];
 


### PR DESCRIPTION
There are cases that it helps to know the constants that are been used by the generator.

This allows for example to regenerate the url to access the api as if we were using the $resource API, but in cases where AJAX can't be used, for example when downloading a file. Knowing the base url is necessary as it may change depending on how the app is been served, and it's better to provide this through the client API than through build time variables IMHO. An example can be found at https://github.com/idbaigorria/loopback-angular-admin/commit/39c5647a8167835a7bee861d0f156a9270047dab here we are passing authentication information as well as it's required for the download.

I wasn't sure about how to name the module so I used <module>_CONSTANTS to avoid getting collisions with other names in the namespace. Any suggestions?
