### PR TITLE
#61-Remove token and user id keys from session and local storage on logout

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -80,7 +80,7 @@ module.factory(
           interceptor: {
             response: function(response) {
               LoopBackAuth.clearUser();
-              LoopBackAuth.save();
+              LoopBackAuth.clearStorage();
               return response.resource;
             }
           }
@@ -253,6 +253,7 @@ module.factory(
 module
   .factory('LoopBackAuth', function() {
     var props = ['accessTokenId', 'currentUserId'];
+    var propsPrefix = '$LoopBack$';
 
     function LoopBackAuth() {
       var self = this;
@@ -283,18 +284,25 @@ module
       this.currentUserData = null;
     }
 
+    LoopBackAuth.prototype.clearStorage = function() {
+      props.forEach(function(name) {
+        save(sessionStorage, name, null);
+        save(localStorage, name, null);
+      });
+    };
+
     return new LoopBackAuth();
 
     // Note: LocalStorage converts the value to string
     // We are using empty string as a marker for null/undefined values.
     function save(storage, name, value) {
-      var key = '$LoopBack$' + name;
+      var key = propsPrefix + name;
       if (value == null) value = '';
       storage[key] = value;
     }
 
     function load(name) {
-      var key = '$LoopBack$' + name;
+      var key = propsPrefix + name;
       return localStorage[key] || sessionStorage[key] || null;
     }
   })

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -395,6 +395,34 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
           .catch(util.throwHttpError);
       });
 
+      it('clears authentication data in local and session storage ' +
+        'on logout when rememberMe=true and page has been reloaded after login',
+      function() {
+        return givenLoggedInUser(null, { rememberMe: true })
+          .then(function() {
+            // If page is reloaded or browser is closed and then reopened again
+            // the Auth.rememberMe is set to undefined.
+            var auth = $injector.get('LoopBackAuth');
+            auth.rememberMe = undefined;
+
+            return Customer.logout().$promise;
+          })
+          .then(function() {
+            // Check that localStorage was cleared
+            expect(localStorage.getItem('$LoopBack$accessTokenId'),
+              'localStorage: accessTokenId').to.equal('');
+            expect(localStorage.getItem('$LoopBack$currentUserId'),
+              'localStorage: currentUserId').to.equal('');
+
+            // Check that sessionStorage was cleared
+            expect(sessionStorage.getItem('$LoopBack$accessTokenId'),
+              'sessionStorage: accessTokenId').to.equal('');
+            expect(sessionStorage.getItem('$LoopBack$currentUserId'),
+              'sessionStorage: currentUserId').to.equal('');
+          })
+          .catch(util.throwHttpError);
+      });
+
       it('returns stub 401 for User.getCurrent when not logged in', function() {
         return Customer.getCurrent().$promise
           .then(function() {


### PR DESCRIPTION
Remove 'accessTokenId' and 'currentUserId' keys from session and local storage on logout.
Fixes #61 
