### PR TITLE
services: fix ngdoc @param missing a description

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -368,7 +368,7 @@ module
      * @ngdoc method
      * @name <%-: moduleName %>.LoopBackResourceProvider#setUrlBase
      * @methodOf <%-: moduleName %>.LoopBackResourceProvider
-     * @param {string} url
+     * @param {string} url The URL to use, e.g. `/api` or `//example.com/api`.
      * @description
      * Change the URL of the REST API server. By default, the URL provided
      * to the code generator (`lb-ng` or `grunt-loopback-sdk-angular`) is used.


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/loopbackjs/P1FoK8NBLwg
