### PR TITLE
WIP: Allow multiple endpoints

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -1,6 +1,5 @@
 (function(window, angular, undefined) {'use strict';
 
-var urlBase = <%-: urlBase | q %>;
 var authHeader = 'authorization';
 
 /**
@@ -15,121 +14,143 @@ var authHeader = 'authorization';
  */
 var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
 
-<% for (var modelName in models) {
-     var meta = models[modelName];
-
-     // capitalize the model name
-     modelName = modelName[0].toUpperCase() + modelName.slice(1);
--%>
+<% //TODO: docs -%>
 /**
  * @ngdoc object
- * @name <%-: moduleName %>.<%-: modelName %>
- * @header <%-: moduleName %>.<%-: modelName %>
+ * @name <%-: moduleName %>.Loopback
+ * @header <%-: moduleName %>.Loopback
  * @object
  *
  * @description
  *
- * A $resource object for interacting with the `<%-: modelName %>` model.
- *
- * ## Example
- *
- * See
- * {@link http://docs.angularjs.org/api/ngResource.$resource#example $resource}
- * for an example of using this object.
- *
+ * Object that gives you access to the LoopBack models
 <% /*
     * TODO(bajtos) provide an example of performing basic CrUD operations,
     * including filter/where find query
     */ -%>
  */
 module.factory(
-  <%-: modelName | q %>,
+  <%-: moduleName | q %>,
   ['LoopBackResource', 'LoopBackAuth', '$injector', function(Resource, LoopBackAuth, $injector) {
-    var R = Resource(
-      urlBase + <%-: meta.ctor.getFullPath() | q %>,
+    var lb = function LoopBack(_urlBase) {
+      this.urlBase = _urlBase;
+
+<% for (var modelName in models) {
+     var meta = models[modelName];
+
+     // capitalize the model name
+     modelName = modelName[0].toUpperCase() + modelName.slice(1);
+-%>
+       /**
+        * @ngdoc object
+        * @name <%-: moduleName %>.Loopback.<%-: modelName %>
+        * @header <%-: moduleName %>.Loopback.<%-: modelName %>
+        * @object
+        *
+        * @description
+        *
+        * A $resource object for interacting with the `<%-: modelName %>` model.
+        *
+        * @param {string} url The URL to use, e.g. `/api` or `//example.com/api`.
+        *
+        * ## Example
+        *
+        * See
+        * {@link http://docs.angularjs.org/api/ngResource.$resource#example $resource}
+        * for an example of using this object.
+        *
+<%        /*
+           * TODO(bajtos) provide an example of performing basic CrUD operations,
+           * including filter/where find query
+           */ 
+-%>
+       */
+
+      this.<%-: modelName %> = Resource(
+        this.urlBase + <%-: meta.ctor.getFullPath() | q %>,
 <% /*
         Constructor arguments are hardcoded for now.
         We should generate it from sharedCtor.accepts instead.
 */ -%>
-      { 'id': '@id' },
-      {
+        { 'id': '@id' },
+        {
 <% meta.methods.forEach(function(action) {
      var methodName = action.name.split('.').join('$');
 -%>
 <%   ngdocForMethod(modelName, methodName, action); -%>
-        <%-: methodName | q %>: {
+          <%-: methodName | q %>: {
 <% if (action.isReturningArray()) { -%>
-          isArray: true,
+            isArray: true,
 <% } -%>
 <% if (meta.isUser && methodName === 'login') { -%>
-          params: {
-            include: "user"
-          },
-          interceptor: {
-            response: function(response) {
-              var accessToken = response.data;
-              LoopBackAuth.setUser(accessToken.id, accessToken.userId, accessToken.user);
-              LoopBackAuth.rememberMe = response.config.params.rememberMe !== false;
-              LoopBackAuth.save();
-              return response.resource;
-            }
-          },
+            params: {
+              include: "user"
+            },
+            interceptor: {
+              response: function(response) {
+                var accessToken = response.data;
+                LoopBackAuth.setUser(accessToken.id, accessToken.userId, accessToken.user);
+                LoopBackAuth.rememberMe = response.config.params.rememberMe !== false;
+                LoopBackAuth.save();
+                return response.resource;
+              }
+            },
 <% } else if (meta.isUser && methodName === 'logout') { -%>
-          interceptor: {
-            response: function(response) {
-              LoopBackAuth.clearUser();
-              LoopBackAuth.clearStorage();
-              return response.resource;
-            }
-          },
+            interceptor: {
+              response: function(response) {
+                LoopBackAuth.clearUser();
+                LoopBackAuth.clearStorage();
+                return response.resource;
+              }
+            },
 <% } -%>
-          url: urlBase + <%-: action.getFullPath() | q %>,
-          method: <%-: action.getHttpMethod() | q %>
-        },
+            url: this.urlBase + <%-: action.getFullPath() | q %>,
+            method: <%-: action.getHttpMethod() | q %>
+          },
 <% }); // meta.methods.foreach -%>
 <% if (meta.isUser) { -%>
-
-        /**
-         * @ngdoc method
-         * @name <%- moduleName %>.<%- modelName %>#getCurrent
-         * @methodOf <%- moduleName %>.<%- modelName %>
-         *
-         * @description
-         *
-         * Get data of the currently logged user. Fail with HTTP result 401
-         * when there is no user logged in.
-         *
-         * @param {function(Object,Object)=} successCb
-         *    Success callback with two arguments: `value`, `responseHeaders`.
-         *
-         * @param {function(Object)=} errorCb Error callback with one argument:
-         *    `httpResponse`.
-         *
-         * @returns {Object} An empty reference that will be
-         *   populated with the actual data once the response is returned
-         *   from the server.
-         */
-        "getCurrent": {
-           url: urlBase + <%-: meta.getPath() | q %> + "/:id",
-           method: "GET",
-           params: {
-             id: function() {
-              var id = LoopBackAuth.currentUserId;
-              if (id == null) id = '__anonymous__';
-              return id;
+  
+          /**
+           * @ngdoc method
+           * @name <%- moduleName %>.Loopback.<%- modelName %>#getCurrent
+           * @methodOf <%- moduleName %>.Loopback.<%- modelName %>
+           *
+           * @description
+           *
+           * Get data of the currently logged user. Fail with HTTP result 401
+           * when there is no user logged in.
+           *
+           * @param {function(Object,Object)=} successCb
+           *    Success callback with two arguments: `value`, `responseHeaders`.
+           *
+           * @param {function(Object)=} errorCb Error callback with one argument:
+           *    `httpResponse`.
+           *
+           * @returns {Object} An empty reference that will be
+           *   populated with the actual data once the response is returned
+           *   from the server.
+           */
+          "getCurrent": {
+             url: this.urlBase + <%-: meta.getPath() | q %> + "/:id",
+             method: "GET",
+             params: {
+               id: function() {
+                var id = LoopBackAuth.currentUserId;
+                if (id == null) id = '__anonymous__';
+                return id;
+              },
             },
-          },
-          interceptor: {
-            response: function(response) {
-              LoopBackAuth.currentUserData = response.data;
-              return response.resource;
-            }
-          },
-          __isGetCurrentUser__ : true
-        }
+            interceptor: {
+              response: function(response) {
+                LoopBackAuth.currentUserData = response.data;
+                return response.resource;
+              }
+            },
+            __isGetCurrentUser__ : true
+          }
 <% } -%>
-      }
-    );
+        }
+      );
 
 
 <% meta.methods.forEach(function(action) {
@@ -138,7 +159,7 @@ module.factory(
       var aliasMethod = alias.split('.').join('$');
 
       ngdocForMethod(modelName, aliasMethod, action); -%>
-        R[<%-: aliasMethod | q %>] = R[<%-: methodName | q %>];
+      this.<%-: modelName %>[<%-: aliasMethod | q %>] = this.<%-: modelName %>[<%-: methodName | q %>];
 <%  }); // aliases.foreach
   }); // meta.methods.foreach
 -%>
@@ -146,56 +167,56 @@ module.factory(
 <% if (meta.isUser) { -%>
         /**
          * @ngdoc method
-         * @name <%- moduleName %>.<%- modelName %>#getCachedCurrent
-         * @methodOf <%- moduleName %>.<%- modelName %>
+         * @name <%- moduleName %>.Loopback.<%- modelName %>#getCachedCurrent
+         * @methodOf <%- moduleName %>.Loopback.<%- modelName %>
          *
          * @description
          *
          * Get data of the currently logged user that was returned by the last
-         * call to {@link <%- moduleName %>.<%- modelName %>#login} or
-         * {@link <%- moduleName %>.<%- modelName %>#getCurrent}. Return null when there
+         * call to {@link <%- moduleName %>.Loopback.<%- modelName %>#login} or
+         * {@link <%- moduleName %>.Loopback.<%- modelName %>#getCurrent}. Return null when there
          * is no user logged in or the data of the current user were not fetched
          * yet.
          *
          * @returns {Object} A <%- modelName %> instance.
          */
-        R.getCachedCurrent = function() {
+        this.<%-: modelName %>.getCachedCurrent = function() {
           var data = LoopBackAuth.currentUserData;
           return data ? new R(data) : null;
         };
 
         /**
          * @ngdoc method
-         * @name <%- moduleName %>.<%- modelName %>#isAuthenticated
-         * @methodOf <%- moduleName %>.<%- modelName %>
+         * @name <%- moduleName %>.Loopback.<%- modelName %>#isAuthenticated
+         * @methodOf <%- moduleName %>.Loopback.<%- modelName %>
          *
          * @returns {boolean} True if the current user is authenticated (logged in).
          */
-        R.isAuthenticated = function() {
+        this.<%-: modelName %>.isAuthenticated = function() {
           return this.getCurrentId() != null;
         };
 
         /**
          * @ngdoc method
-         * @name <%- moduleName %>.<%- modelName %>#getCurrentId
-         * @methodOf <%- moduleName %>.<%- modelName %>
+         * @name <%- moduleName %>.Loopback.<%- modelName %>#getCurrentId
+         * @methodOf <%- moduleName %>.Loopback.<%- modelName %>
          *
          * @returns {Object} Id of the currently logged-in user or null.
          */
-        R.getCurrentId = function() {
+        this.<%-: modelName %>.getCurrentId = function() {
           return LoopBackAuth.currentUserId;
         };
 <% } -%>
 
-    /**
-    * @ngdoc property
-    * @name <%- moduleName %>.<%- modelName %>#modelName
-    * @propertyOf <%- moduleName %>.<%- modelName %>
-    * @description
-    * The name of the model represented by this $resource,
-    * i.e. `<%- modelName %>`.
-    */
-    R.modelName = <%-: modelName | q %>;
+      /**
+      * @ngdoc property
+      * @name <%- moduleName %>.Loopback.<%- modelName %>#modelName
+      * @propertyOf <%- moduleName %>.Loopback.<%- modelName %>
+      * @description
+      * The name of the model represented by this $resource,
+      * i.e. `<%- modelName %>`.
+      */
+      this.<%-: modelName %>.modelName = <%-: modelName | q %>;
 
 <% for (var scopeName in meta.scopes) {
       var scope = meta.scopes[scopeName];
@@ -206,19 +227,19 @@ module.factory(
 
       if (Object.keys(scopeMethods).length > 1) {
 -%>
-    /**
-     * @ngdoc object
-     * @name lbServices.<%- modelName %>.<%- scopeName %>
-     * @header lbServices.<%- modelName %>.<%- scopeName %>
-     * @object
-     * @description
-     *
-     * The object `<%- modelName %>.<%- scopeName %>` groups methods
-     * manipulating `<%- targetClass %>` instances related to `<%- modelName %>`.
-     *
-     * Call {@link lbServices.<%- modelName %>#<%- scopeName %> <%- modelName %>.<%- scopeName %>()}
-     * to query all related instances.
-     */
+      /**
+       * @ngdoc object
+       * @name lbServices.<%- modelName %>.<%- scopeName %>
+       * @header lbServices.<%- modelName %>.<%- scopeName %>
+       * @object
+       * @description
+       *
+       * The object `<%- modelName %>.<%- scopeName %>` groups methods
+       * manipulating `<%- targetClass %>` instances related to `<%- modelName %>`.
+       *
+       * Call {@link lbServices.<%- modelName %>#<%- scopeName %> <%- modelName %>.<%- scopeName %>()}
+       * to query all related instances.
+       */
 
 <%
       }
@@ -235,20 +256,22 @@ module.factory(
         var ngMethod = names.pop();
         var ngClass = [modelName].concat(names).join('.');
 
-        ngdocForMethod(ngClass, ngMethod, action, targetClass);
+      ngdocForMethod(ngClass, ngMethod, action, targetClass);
 -%>
-        R.<%- methodName %> = function() {
-          var TargetResource = $injector.get(<%-: targetClass | q %>);
-          var action = TargetResource[<%-: action.name | q %>];
-          return action.apply(R, arguments);
-        };
+      this.<%-: modelName %>.<%- methodName %> = function() {
+        var TargetResource = $injector.get(<%-: targetClass | q %>);
+        var action = TargetResource[<%-: action.name | q %>];
+        return action.apply(R, arguments);
+      };
 <%    }); // forEach methods name -%>
 <% } // for each scope -%>
-
-    return R;
-  }]);
-
 <% } // for modelName in models -%>
+    }
+
+    return lb;
+  }]
+);
+
 
 module
   .factory('LoopBackAuth', function() {
@@ -315,9 +338,9 @@ module
         'request': function(config) {
 
           // filter out non urlBase requests
-          if (config.url.substr(0, urlBase.length) !== urlBase) {
-            return config;
-          }
+          //if (config.url.substr(0, urlBase.length) !== urlBase) {
+          //  return config;
+          //}
 
           if (LoopBackAuth.accessTokenId) {
             config.headers[authHeader] = LoopBackAuth.accessTokenId;
@@ -372,19 +395,6 @@ module
       authHeader = header;
     };
 
-    /**
-     * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#setUrlBase
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
-     * @param {string} url The URL to use, e.g. `/api` or `//example.com/api`.
-     * @description
-     * Change the URL of the REST API server. By default, the URL provided
-     * to the code generator (`lb-ng` or `grunt-loopback-sdk-angular`) is used.
-     */
-    this.setUrlBase = function(url) {
-      urlBase = url;
-    };
-
     this.$get = ['$resource', function($resource) {
       return function(url, params, actions) {
         var resource = $resource(url, params, actions);
@@ -416,28 +426,28 @@ function ngdocForMethod(modelName, methodName, action, responseModelName) {
 <%
   if (action.internal) {
 -%>
-        // INTERNAL. <%- action.internal %>
+          // INTERNAL. <%- action.internal %>
 <%
     return;
   }
 -%>
-        /**
-         * @ngdoc method
-         * @name <%- moduleName %>.<%- modelName %>#<%- methodName %>
-         * @methodOf <%- moduleName %>.<%- modelName %>
+          /**
+           * @ngdoc method
+           * @name <%- moduleName %>.Loopback.<%- modelName %>#<%- methodName %>
+           * @methodOf <%- moduleName %>.Loopback.<%- modelName %>
 <% if (action.deprecated) { -%>
-         * @deprecated <%- action.deprecated %>
+           * @deprecated <%- action.deprecated %>
 <% } -%>
-         *
-         * @description
-         *
+           *
+           * @description
+           *
 <% if (!action.description) {
 action.description =  '<em>\n' +
   '(The remote method definition does not provide any description.)\n' +
   '</em>';
 } -%>
-         * <%-: action.description | replace:/\n/g, '\n         * ' %>
-         *
+           * <%-: action.description | replace:/\n/g, '\n         * ' %>
+           *
 <%
 var params = action.accepts;
 var postData;
@@ -450,77 +460,77 @@ if (action.getHttpMethod() == 'POST' || action.getHttpMethod() == 'PUT') {
   });
 }
 -%>
-         * @param {Object=} parameters Request parameters.
+           * @param {Object=} parameters Request parameters.
 <% if (params.length == 0) { -%>
-         *
-         *   This method does not accept any parameters.
-         *   Supply an empty object or omit this argument altogether.
+           *
+           *   This method does not accept any parameters.
+           *   Supply an empty object or omit this argument altogether.
 <% } else { params.forEach(function(arg) { -%>
-         *
-         *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
+           *
+           *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
 (arg.description || '').replace(/\n/g, '\n         *   ') %>
 <%   if (meta.isUser && methodName === 'login' && arg.arg === 'include') { -%>
-         *   Default value: `user`.
+           *   Default value: `user`.
 <%   } -%>
 <% }); } -%>
 <% if (meta.isUser && methodName === 'login') { -%>
-         *
-         *  - `rememberMe` - `boolean` - Whether the authentication credentials
-         *     should be remembered in localStorage across app/browser restarts.
-         *     Default: `true`.
+           *
+           *  - `rememberMe` - `boolean` - Whether the authentication credentials
+           *     should be remembered in localStorage across app/browser restarts.
+           *     Default: `true`.
 <% } -%>
 <% if (postData) { -%>
-         *
-         * @param {Object} postData Request data.
+           *
+           * @param {Object} postData Request data.
 <% if (postData.length == 0) { -%>
-         *
-         * This method does not accept any data. Supply an empty object.
+           *
+           * This method does not accept any data. Supply an empty object.
 <% } else if (postData.length == 1 && postData[0].http &&
       postData[0].http.source == 'body') { -%>
-         *
-         * This method expects a subset of model properties as request parameters.
+           *
+           * This method expects a subset of model properties as request parameters.
 <% } else {
 postData.forEach(function(arg) { -%>
-         *
-         *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
+           *
+           *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
 (arg.description || '').replace(/\n/g, '\n         *   ') %>
 <%   });
   }
 } -%>
-         *
+           *
 <% var returnType = action.isReturningArray() ? 'Array.<Object>': 'Object'; -%>
-         * @param {function(<%- returnType %>,Object)=} successCb
-         *   Success callback with two arguments: `value`, `responseHeaders`.
-         *
-         * @param {function(Object)=} errorCb Error callback with one argument:
-         *   `httpResponse`.
-         *
-         * @returns {<%- returnType %>} An empty reference that will be
-         *   populated with the actual data once the response is returned
-         *   from the server.
-         *
+           * @param {function(<%- returnType %>,Object)=} successCb
+           *   Success callback with two arguments: `value`, `responseHeaders`.
+           *
+           * @param {function(Object)=} errorCb Error callback with one argument:
+           *   `httpResponse`.
+           *
+           * @returns {<%- returnType %>} An empty reference that will be
+           *   populated with the actual data once the response is returned
+           *   from the server.
+           *
 <% if (!action.returns || action.returns.length == 0) { -%>
-         * This method returns no data.
+           * This method returns no data.
 <% } else if (action.returns[0].root) { -%>
 <%   if (action.returns[0].description) { -%>
-         * <%- action.returns[0].description
+           * <%- action.returns[0].description
 .replace(/\n/g, '\n         * ').trimRight() %>
 <%   } else { -%>
-         * <em>
-         * (The remote method definition does not provide any description.
-         * This usually means the response is a `<%- responseModelName || modelName %>` object.)
-         * </em>
+           * <em>
+           * (The remote method definition does not provide any description.
+           * This usually means the response is a `<%- responseModelName || modelName %>` object.)
+           * </em>
 <%   } -%>
 <% } else { -%>
-         * Data properties:
+           * Data properties:
 <%   action.returns.forEach(function(arg) { -%>
-         *
-         *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
+           *
+           *  - `<%- arg.arg %>` – `{<%- getJsDocType(arg)  %>}` - <%-
 (arg.description || '').replace(/\n/g, '\n         *   ') %>
 <%   });
    }
 -%>
-         */
+           */
 <% } // end of ngdocForMethod -%>
 
 })(window, window.angular);


### PR DESCRIPTION
The idea here is to allow the angular-sdk to connect to one or more backends based on runtime configuration instead of hard-coding the `urlBase`.

Eg:
```
angular.module('app').controller('MainCtrl',
  [
    '$scope', 'lbServices',
    function($scope, Loopback) {
      var lb = new Loopback('http://localhost:5000/api');

      lb.MyModel.count(function(data){
        $scope.myModelCount = data.count;
      });
    }
  ]
);
```

Things to work out:
* [ ] How does this affect authentication
* [ ] ...