### PR TITLE
added model naming strategies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+2015-06-17, Version 1.4.0
+=========================
+
+ * Add createMany functionallity (Jonathan Casarrubias)
+
+ * Support "accepts" arguments mapped to URL params (Matt McCabe)
+
+ * Fix bad CLA URL in CONTRIBUTING.md (Ryan Graham)
+
+
 2014-11-19, Version 1.3.7
 =========================
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,5 +1,7 @@
 var fs = require('fs');
 var ejs = require('ejs');
+var changeCase = require('change-case'); 
+var ngNameCase = "";
 
 ejs.filters.q = function(obj) {
   return JSON.stringify(obj, null, 2 );
@@ -24,11 +26,11 @@ ejs.filters.q = function(obj) {
  * @returns {string} The generated javascript code.
  * @header generateServices
  */
-module.exports = function generateServices(app, ngModuleName, apiUrl) {
+module.exports = function generateServices(app, ngModuleName, apiUrl, ngNameCase) {
   ngModuleName = ngModuleName || 'lbServices';
   apiUrl = apiUrl || '/';
-
-  var models = describeModels(app);
+  
+  var models = describeModels(app, ngNameCase);
 
   var servicesTemplate = fs.readFileSync(
     require.resolve('./services.template.ejs'),
@@ -42,7 +44,41 @@ module.exports = function generateServices(app, ngModuleName, apiUrl) {
   });
 };
 
-function describeModels(app) {
+
+/**
+ * this function changes the case of the modelname to match the supplied strategy
+ * and has been added to allow for more consistent naming conventions between loopback and the angular services
+ *
+ * there are three options:
+ *
+ * "upperCaseFirst" (default / current behaviour): changes customer to Customer, foo_bar to Foo_bar
+ * "pascalCase" : changes customer to Customer, foo_bar to FooBar
+ * "camelCase" : changes customer to customer, foo_bar to fooBar
+ */
+
+function caseModelName(modelName,ngNameCase) {
+  // change the model name according the selected strategy
+  switch(ngNameCase) {
+    case 'pascalCase':
+      modelName = changeCase.pascalCase(modelName)
+      break;
+
+    case 'camelCase':
+      modelName = changeCase.camelCase(modelName)
+    break;
+
+    default:
+      modelName = changeCase.upperCaseFirst(modelName)
+      break;
+  } 
+
+  console.log(modelName)
+
+  return modelName;
+  
+}
+
+function describeModels(app,ngNameCase) {
   var result = {};
   app.handler('rest').adapter.getClasses().forEach(function(c) {
     var name = c.name;
@@ -88,6 +124,8 @@ function describeModels(app) {
 
     c.isUser = c.sharedClass.ctor.prototype instanceof app.loopback.User ||
       c.sharedClass.ctor.prototype === app.loopback.User.prototype;
+    
+    c._ngName = caseModelName(name,ngNameCase)  
     result[name] = c;
   });
 

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -19,7 +19,7 @@ var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
      var meta = models[modelName];
 
      // capitalize the model name
-     modelName = modelName[0].toUpperCase() + modelName.slice(1);
+     modelName = meta._ngName;
 -%>
 /**
  * @ngdoc object

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "loopback-datasource-juggler": "^2.0",
     "mocha": "~1.18.0",
     "morgan": "^1.2",
-    "requirejs": "^2.1.9"
+    "requirejs": "^2.1.9",
+    "change-case": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-sdk-angular",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "Tool for auto-generating Angular $resource services for LoopBack",
   "main": "index.js",
   "scripts": {

--- a/parse-helper.js
+++ b/parse-helper.js
@@ -18,3 +18,7 @@ exports.moduleName = function(script) {
 exports.baseUrl = function(script) {
   return parse(script, /var urlBase = "([^"]*)";/);
 };
+
+exports.ngNameCase = function(script) {
+  return parse(script, /var ngNameCase = "upperCaseFirst";/);
+};


### PR DESCRIPTION
added the ability to specify the model naming strategy for the loopback services models
there are three options:
"upperCaseFirst" (default / current behaviour): changes customer to Customer, foo_bar to Foo_bar
"pascalCase" : changes customer to Customer, foo_bar to FooBar
"camelCase" : changes customer to customer, foo_bar to fooBar

this option is specified by the -c option on the lb-ng command