### PR TITLE
Support remote methods named like scope methods

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -59,7 +59,7 @@ function describeModels(app) {
     // the sharedCtor parameters should be added to the parameters
     // of prototype methods.
     c.methods.forEach(function fixArgsOfPrototypeMethods(method, key) {
-      if(method.name=='create'){ 
+      if (method.name=='create') {
         var createMany = Object.create(method);
             createMany.name = 'createMany';
             createMany.isReturningArray = function() { return true; };
@@ -125,7 +125,8 @@ function buildScopeMethod(models, modelName, method) {
   var op = match[1];
   var scopeName = match[2];
   var modelPrototype = modelClass.sharedClass.ctor.prototype;
-  var targetClass = modelPrototype[scopeName]._targetClass;
+  var targetClass = modelPrototype[scopeName] &&
+      modelPrototype[scopeName]._targetClass;
 
   if (modelClass.scopes[scopeName] === undefined) {
     if (!targetClass) {


### PR DESCRIPTION
This PR supersedes #160.

An example that was crashing the generator before this fix:

    ETUser.remoteMethod(
        '__get__spaces',
        {
          isStatic: false,
          description: 'Get the users spaces',
          http: {path: '/spaces', verb: 'get'},
          returns: {arg: 'spaces', type: 'array', root: true}
        }
      );

Fix #159 