### PR TITLE
Fix request interceptor to process all requests on same host as urlBase

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -3,6 +3,13 @@
 var urlBase = <%-: urlBase | q %>;
 var authHeader = 'authorization';
 
+function getHost(url) {
+  var m = url.match(/^(?:https?:)?\/\/([^\/]+)/);
+  return m ? m[1] : null;
+}
+
+var urlBaseHost = getHost(urlBase) || location.host;
+
 /**
  * @ngdoc overview
  * @name <%- moduleName %>
@@ -321,8 +328,9 @@ module
       return {
         'request': function(config) {
 
-          // filter out non urlBase requests
-          if (config.url.substr(0, urlBase.length) !== urlBase) {
+          // filter out external requests
+          var host = getHost(config.url);
+          if (host && host !== urlBaseHost) {
             return config;
           }
 
@@ -390,6 +398,7 @@ module
      */
     this.setUrlBase = function(url) {
       urlBase = url;
+      urlBaseHost = getHost(urlBase) || location.host;
     };
 
     /**


### PR DESCRIPTION
Allow request interceptor to insert auth header on all requests matching the same host as urlBase.
The host includes the port, if supplied.
If no host is supplied for urlBase (e.g. `"/api"`) then location.host is used for the comparison.
All requests with no host automatically pass and get the auth header inserted.

This allows other endpoints of the loopback app (*not* in urlBase) to receive the AccessToken.