### PR TITLE
Fix angular service name contain non-alphanumeric characters. Ex: Post-tag, ...

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -45,7 +45,7 @@ module.exports = function generateServices(app, ngModuleName, apiUrl) {
 function describeModels(app) {
   var result = {};
   app.handler('rest').adapter.getClasses().forEach(function(c) {
-    var name = c.name;
+    var name = c.name.replace(/[^A-z]/g, '');
 
     if (!c.ctor) {
       // Skip classes that don't have a shared ctor


### PR DESCRIPTION
Fix angular serivce name contain non-alphanumeric characters. 
Ex:
```
module.factory(
  "Tagged-post",
  ['LoopBackResource', 'LoopBackAuth', '$injector', function(Resource, LoopBackAuth, $injector) {
...
```

And after that: 
```
module.factory(
  "Taggedpost",
  ['LoopBackResource', 'LoopBackAuth', '$injector', function(Resource, LoopBackAuth, $injector) {
...
```