### PR TITLE
WIP : Add description from model meta to docs template

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -46,6 +46,7 @@ function describeModels(app) {
   var result = {};
   app.handler('rest').adapter.getClasses().forEach(function(c) {
     var name = c.name;
+    c.description = c.sharedClass.ctor.settings.description;
 
     if (!c.ctor) {
       // Skip classes that don't have a shared ctor

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -30,6 +30,12 @@ var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
  * @description
  *
  * A $resource object for interacting with the `<%-: modelName %>` model.
+<% if ( meta.description ){ -%>
+ *
+ * **Details**
+ *
+ * <%-: meta.description | replace:/\n/gi, '\n * ' %>
+<% } -%>
  *
  * ## Example
  *


### PR DESCRIPTION
#### Dependant:
[rest-adapter.js @ Strong-remoting](https://github.com/strongloop/strong-remoting/pull/255)  providing sharedClass in restClass


#### Change:
services.js adds `description` to meta used in `services.template.ejs`
services.template.ejs now apends model `description` defined in loopback
after the generic description.

@bajtos @ritch  As of now the description is only appended to the hard coded description as I'm assuming many models do not have a description in model. 

https://github.com/strongloop/loopback-sdk-angular/issues/132

Signed-off-by: David Cheung <davidcheung@ca.ibm.com>