### PR TITLE
Can include model schema definitions in generated $resources

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -24,7 +24,8 @@ ejs.filters.q = function(obj) {
  * @returns {string} The generated javascript code.
  * @header generateServices
  */
-module.exports = function generateServices(app, ngModuleName, apiUrl, includeSchemas) {
+module.exports = function generateServices(app, ngModuleName, apiUrl, 
+    includeSchemas) {
   ngModuleName = ngModuleName || 'lbServices';
   apiUrl = apiUrl || '/';
 
@@ -36,7 +37,7 @@ module.exports = function generateServices(app, ngModuleName, apiUrl, includeSch
       models[modelName].modelSchema = {
         name: modelName,
         properties: modelProperties
-      }
+      };
     }
   }
   var servicesTemplate = fs.readFileSync(

--- a/lib/services.js
+++ b/lib/services.js
@@ -24,12 +24,21 @@ ejs.filters.q = function(obj) {
  * @returns {string} The generated javascript code.
  * @header generateServices
  */
-module.exports = function generateServices(app, ngModuleName, apiUrl) {
+module.exports = function generateServices(app, ngModuleName, apiUrl, includeSchemas) {
   ngModuleName = ngModuleName || 'lbServices';
   apiUrl = apiUrl || '/';
 
   var models = describeModels(app);
 
+  if (includeSchemas === true) {
+    for (var modelName in models) {
+      var modelProperties = app.models[modelName].definition.rawProperties;
+      models[modelName].modelSchema = {
+        name: modelName,
+        properties: modelProperties
+      }
+    }
+  }
   var servicesTemplate = fs.readFileSync(
     require.resolve('./services.template.ejs'),
     { encoding: 'utf-8' }

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -260,7 +260,7 @@ module.factory(
      * @description
      * The schema of the model represented by this $resource
      */
-    R.schema = <%- JSON.stringify(meta.modelSchema, null, '\t') -%>
+    R.schema = <%- JSON.stringify(meta.modelSchema, null, '\t') -%>;
 
 
 <% } -%>

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -252,6 +252,18 @@ module.factory(
 <%    }); // forEach methods name -%>
 <% } // for each scope -%>
 
+<% if (meta.modelSchema) { -%>
+    /**
+     * @ngdoc object
+     * @name <%-: moduleName %>.<%- modelName %>#schema
+     * @propertyOf <%-: moduleName %>.<%- modelName %>
+     * @description
+     * The schema of the model represented by this $resource
+     */
+    R.schema = <%- JSON.stringify(meta.modelSchema, null, '\t') -%>
+
+
+<% } -%>
     return R;
   }]);
 

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -832,6 +832,33 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
           });
       });
     });
+    
+    describe('$resource for model generated with include schema', function() {
+      var $injector;
+      before(function() {
+        return given.servicesForLoopBackApp(
+          {
+            models: {
+              'pretender': {},
+            },
+            includeSchema: true,
+            setupFn: (function(app, cb) {
+              var Pretender = app.models.Pretender;
+              cb();
+            }).toString(),
+          })
+          .then(function(createInjector) {
+            $injector = createInjector();
+          });
+      });
+
+      it('has a schema method generated', function() {
+        var Pretender = $injector.get('Pretender');
+        var methodNames = Object.keys(Pretender);
+        console.log('methods', methodNames);
+        expect(methodNames).to.include.members(['schema']);
+      });
+    });
 
     describe('for models with belongsTo relation', function() {
       var $injector, Town, Country, testData;

--- a/test.e2e/test-server.js
+++ b/test.e2e/test-server.js
@@ -66,6 +66,7 @@ masterApp.post('/setup', function(req, res, next) {
   var name = opts.name;
   var models = opts.models;
   var enableAuth = opts.enableAuth;
+  var includeSchema = opts.includeSchema;
   var setupFn = compileSetupFn(name, opts.setupFn);
 
   if (!name)
@@ -105,7 +106,7 @@ masterApp.post('/setup', function(req, res, next) {
     }
 
     try {
-      servicesScript = generator.services(lbApp, name, apiUrl);
+      servicesScript = generator.services(lbApp, name, apiUrl, includeSchema);
     } catch (err) {
       console.error('Cannot generate services script:', err.stack);
       servicesScript = 'throw new Error("Error generating services script.");';


### PR DESCRIPTION
Hi,

we're working on a Kendo data source that can use Strongloop REST services as 'transport' and while things are working just fine for read operations for updates the Kendo data source require some schema information - the model primary key is mandatory else no update operation can take place. 

While one can add that information manually when defining the data source it's a pita not to use the information already available in our models. We've just added an option to include the model definition (properties) when generating the angular resources, this is not included by default so if you think we can merge that back in 'master' we would rather not keep the fork alive. There is a minor change in the client to accommodate this.

Best regards,
Marian Edu

marian.edu@acorn.ro
www.acorn-it.com
www.akera.io
