### PR TITLE
CommonJS package manager support

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -1,5 +1,5 @@
 /* CommonJS package manager support */
-if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
   module.exports = <%-: moduleName | q %>;
 }
 

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -1,3 +1,8 @@
+/* CommonJS package manager support */
+if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){
+  module.exports = <%-: moduleName | q %>;
+}
+
 (function(window, angular, undefined) {'use strict';
 
 var urlBase = <%-: urlBase | q %>;


### PR DESCRIPTION
I usually use Browserify and Webpack to bundle my code and find it very useful if the generated module can allow the use of CommonJS package manager and ES6 modules.

```js
import lbServices from './lb-services';

angular.module('app', [lbServices]);
```

Thanks in advance.
Djamel