### PR TITLE
Fix npm test on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublish": "node ./apidocs/describe-builtin-models.js",
     "pretest": "jshint . && bower install",
-    "test": "node ./test.e2e/test-server.js node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
+    "test": "node ./test.e2e/test-server.js node node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Windows requires `node` to be specified for `npm test` to work
or else we get error as follow:
```coffee
child_process.spawn failed { [Error: spawn node_modules/karma/bin/karma ENOENT]
  code: 'ENOENT',
  errno: 'ENOENT',
  syscall: 'spawn node_modules/karma/bin/karma',
  path: 'node_modules/karma/bin/karma',
  spawnargs: [ 'start', '--single-run', '--browsers', 'PhantomJS' ] }
npm ERR! Test failed.  See above for more details.
```