### PR TITLE
Patch safari-private-mode localStorage unusable

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -326,9 +326,13 @@ module
     // Note: LocalStorage converts the value to string
     // We are using empty string as a marker for null/undefined values.
     function save(storage, name, value) {
-      var key = propsPrefix + name;
-      if (value == null) value = '';
-      storage[key] = value;
+      try {
+        var key = propsPrefix + name;
+        if (value == null) value = '';
+        storage[key] = value;
+      } catch(err) {
+        console.log('Cannot access local/session storage:', err);
+      }
     }
 
     function load(name) {


### PR DESCRIPTION
This patch basically deals with when localStorage uncallable,
fallback to memory instead, this also implies when you refresh it no
longer retains those data

------
##### Work in progress
- [x] how to let user know localStorage has been overriden
- [x] how to properly test what features are gone when in fallback mode
- [x] use keyvalue store as fallback

------------
- [x] Updating approach to `catch and ignore` instead of catch and `override original storage` as many problem will arise because the browser does not refresh, therefore window.localStorage functionality will lose the data until refresh page if its overriden 

Fixes #179