### PR TITLE
Added getter for AuthHeader value in LoopBackResource

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -409,6 +409,17 @@ module
 
     /**
      * @ngdoc method
+     * @name <%-: moduleName %>.LoopBackResourceProvider#getAuthHeader
+     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @description
+     * Get the header name that is used for sending the authentication token.
+     */
+    this.getAuthHeader = function() {
+       return authHeader;
+    };
+
+    /**
+     * @ngdoc method
      * @name <%-: moduleName %>.LoopBackResourceProvider#setUrlBase
      * @methodOf <%-: moduleName %>.LoopBackResourceProvider
      * @param {string} url The URL to use, e.g. `/api` or `//example.com/api`.

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -88,6 +88,18 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
       });
 
       describe('LoopBackResourceProvider', function() {
+        it('has getAuthHeader method', function() {
+          expect(loopBackResourceProvider).to.have.property('getAuthHeader');
+        });
+
+        it('can get authHeader', function() {
+          var authHeader = 'X-Awesome-Token';
+          loopBackResourceProvider.setAuthHeader(authHeader);
+          var gotAuthHeader = loopBackResourceProvider.getAuthHeader();
+
+          return expect(gotAuthHeader).to.equal(authHeader);
+        });
+
         it('has setAuthHeader method', function() {
           expect(loopBackResourceProvider).to.have.property('setAuthHeader');
         });


### PR DESCRIPTION
Sometimes it can be neccessary to get the header field name for authentication out of loopbacks `LoopBackResource`. For example i had to manually upload a file and set the auth token to my http call since the sdk doesn't support this feature.

I updated the template to include a getter for this.