### PR TITLE
Return Date objects from any Angular SDK resource that has a date property

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,8 @@ module.exports = function(config) {
       'test.e2e/test-main.js',
       { pattern: 'node_modules/chai/**/*.js', included: false },
       { pattern: 'node_modules/angular*/**/*.js', included: false },
+      { pattern: 'node_modules/lodash/index.js', included: false },
+      { pattern: 'node_modules/moment/**/*.js', included: false },
       { pattern: 'test.e2e/**/*.js', included: false },
 
       // Include lib/ files to let Karma watch for changes there

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -33,9 +33,139 @@ var urlBaseHost = getHost(urlBase) || location.host;
  */
 var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
 
+module.constant('_', window._)
+module.constant('moment', window.moment)
+
+module.factory('dateTransformer', 
+    function dateTransformerFactory($http, _, moment) {
+        var dateTransformer = {
+
+            toDate: toDate,
+            toLocalIsoString: toLocalIsoString,
+            toZonedIsoString: toZonedIsoString,
+
+            transformResponse: {
+                toDate: transformResponseToDate,
+                toLocalIsoString: transformResponseToLocalIsoString,
+                toZonedIsoString: transformResponseToZonedIsoString
+            },
+
+            transformRequest: {
+                toDate: transformRequestToDate,
+                toLocalIsoString: transformRequestToLocalIsoString,
+                toZonedIsoString: transformRequestToZonedIsoString
+            }
+
+        };
+
+        return dateTransformer;
+
+        function transform(predicate, transformDate) {
+            return function (data) {
+                if (_.isArray(data)) {
+                    return data.map(function (object) {
+                        return transformObject(object, predicate, transformDate);
+                    });
+                } else if (_.isObject(data)) {
+                    return transformObject(data, predicate, transformDate);
+                }
+            };
+        }
+
+        function transformObject(object, predicate, transformDate) {
+            var clonedObject;
+            _.chain(object).pick(predicate).each(function (val, key) {
+                if (_.isDate(object[key]) || _.isString(object[key])) {
+                    if (_.isUndefined(clonedObject)) {
+                        clonedObject = _.clone(object);
+                    }
+                    clonedObject[key] = transformDate(val);
+                }
+            }).value();
+            return _.isUndefined(clonedObject) ? object : clonedObject;
+        }
+
+        function transformResponseWith(transformer) {
+            return $http.defaults.transformResponse.concat(transformer);
+        }
+
+        function transformRequestWith(transformer) {
+            return [transformer].concat($http.defaults.transformRequest);
+        }
+
+        function transformResponseToDate(predicate) {
+            return transformResponseWith(toDate(predicate));
+        }
+
+        function transformResponseToLocalIsoString(predicate) {
+            return transformResponseWith(toLocalIsoString(predicate));
+        }
+
+        function transformResponseToZonedIsoString(predicate) {
+            return transformResponseWith(toZonedIsoString(predicate));
+        }
+
+        function transformRequestToDate(predicate) {
+            return transformRequestWith(toDate(predicate));
+        }
+
+        function transformRequestToLocalIsoString(predicate) {
+            return transformRequestWith(toLocalIsoString(predicate));
+        }
+
+        function transformRequestToZonedIsoString(predicate) {
+            return transformRequestWith(toZonedIsoString(predicate));
+        }
+
+        function toDate(predicate) {
+            return transform(predicate, function (val) {
+                return moment(val).toDate();
+            });
+        }
+
+        function toLocalIsoString(predicate) {
+            return transform(predicate, function (val) {
+                return moment(val).format('YYYY-MM-DDTHH:mm:ss.SSS');
+            });
+        }
+
+        function toZonedIsoString(predicate) {
+            return transform(predicate, function (val) {
+                return moment(val).format();
+            });
+        }
+
+    });
+    
 <% for (var modelName in models) {
      var meta = models[modelName];
-
+     
+     var objectReturningMethods = [];  
+     meta.methods.forEach(function(method) {
+        if(method.internal === undefined && method.returns[0] !== undefined && method.returns[0] !== null && method.returns[0].type !== undefined && models[method.returns[0].type] !== undefined) {
+            objectReturningMethods.push(method.name);
+        }    
+     });
+     
+     var hasDateProperty = false;
+     var dateProperties = [];
+     
+     var properties = meta.sharedClass.ctor.definition.rawProperties;
+     for(var key in properties) {         
+         var propertyDef = properties[key];
+         var type = typeof propertyDef === 'object' ? propertyDef.type : propertyDef;
+         
+         if(typeof type === 'string' && type.toLowerCase() === 'date') {
+             dateProperties.push(key);
+             hasDateProperty = true;
+         }
+     }
+     
+    if(meta.isUser) {
+        dateProperties.push('created');
+        hasDateProperty = true;
+    } 
+          
      // capitalize the model name
      modelName = modelName[0].toUpperCase() + modelName.slice(1);
 -%>
@@ -68,7 +198,11 @@ var module = angular.module(<%-: moduleName | q %>, ['ngResource']);
  */
 module.factory(
   <%-: modelName | q %>,
+  <% if(hasDateProperty) { -%>  
+  ['LoopBackResource', 'LoopBackAuth', '$injector', 'dateTransformer', function(Resource, LoopBackAuth, $injector, dateTransformer) {
+  <% } else { -%>
   ['LoopBackResource', 'LoopBackAuth', '$injector', function(Resource, LoopBackAuth, $injector) {
+  <% } -%>    
     var R = Resource(
       urlBase + <%-: meta.ctor.getFullPath() | q %>,
 <% /*
@@ -115,7 +249,8 @@ module.factory(
           },
 <% } -%>
           url: urlBase + <%-: action.getFullPath() | q %>,
-          method: <%-: action.getHttpMethod() | q %>
+          method: <%-: action.getHttpMethod() | q %><% if(objectReturningMethods.indexOf(methodName) !== -1 && (hasDateProperty  || meta.isUser)) { %>,                    
+          transformResponse: dateTransformer.transformResponse.toDate(['<%- dateProperties.join("', '") %>'])<% } %>
         },
 <% }); // meta.methods.foreach -%>
 <% if (meta.isUser) { -%>
@@ -143,6 +278,7 @@ module.factory(
         "getCurrent": {
            url: urlBase + <%-: meta.getPath() | q %> + "/:id",
            method: "GET",
+           transformResponse: dateTransformer.transformResponse.toDate('created'),
            params: {
              id: function() {
               var id = LoopBackAuth.currentUserId;
@@ -570,5 +706,4 @@ postData.forEach(function(arg) { -%>
 -%>
          */
 <% } // end of ngdocForMethod -%>
-
 })(window, window.angular);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "loopback": "^2.0",
     "loopback-datasource-juggler": "^2.0",
     "mocha": "~1.18.0",
+    "moment": "2.12.0",
     "morgan": "^1.2",
     "phantomjs": "^1.9.19",
     "requirejs": "^2.1.9"

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -65,17 +65,24 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
           };
 
       before(function() {
-        return given.servicesForLoopBackApp(
-          {
-            name: moduleName,
-            models: {
-              MyModel: { name: { type: String, required: true } }
-            }
-          })
-          .then(function(_createInjector) {
-            setTestAngularModuleConfig();
-            createInjector = _createInjector;
-          });
+          return given.servicesForLoopBackApp(
+              {
+                name: moduleName,
+                models: {
+                  MyModel: {
+                    properties: {
+                      name: {
+                        type: 'string',
+                        required: true
+                      }
+                    }
+                  }
+                }
+              })
+              .then(function(_createInjector) {
+                  setTestAngularModuleConfig();
+                  createInjector = _createInjector;
+              });
       });
 
       beforeEach(function() {
@@ -265,8 +272,19 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
       before(function() {
         return given.servicesForLoopBackApp(
           {
+            name: 'customModel',
             models: {
-              MyModel: { name: { type: String, required: true } }
+              MyModel: {
+                properties: {
+                  name: {
+                    type: 'string',
+                    required: true
+                  },
+                  createdOn: {
+                    type: 'date'
+                  }
+                }
+              }
             }
           })
           .then(function(createInjector) {
@@ -374,6 +392,15 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
               util.throwHttpError
             );
             return found.$promise;
+          });
+      });
+
+      it('returns date Object for date property', function() {
+        var obj = MyModel.create({ name: 'new', createdOn: new Date() });
+        return obj.$promise
+          .catch(util.throwHttpError)
+          .then(function() {
+            expect(obj.createdOn).to.be.a('date');
           });
       });
 

--- a/test.e2e/test-main.js
+++ b/test.e2e/test-main.js
@@ -18,7 +18,9 @@ requirejs.config({
     angularResource: 'node_modules/angular-resource/angular-resource',
     angularMocks: 'node_modules/angular-mocks/angular-mocks',
     given: 'test.e2e/given',
-    util: 'test.e2e/util'
+    util: 'test.e2e/util',
+    lodash: 'node_modules/lodash/index',
+    moment: 'node_modules/moment/moment'
   },
 
   shim: {
@@ -31,7 +33,8 @@ requirejs.config({
       deps: ['angular'],
       exports: 'angular.mock'
     },
-    'chai': { exports: 'chai' }
+    'chai': { exports: 'chai' },
+    'lodash': { exports: '_' }
   },
 
   // ask Require.js to load these files (all our tests)
@@ -41,6 +44,8 @@ requirejs.config({
   callback: window.__karma__.start
 });
 
-require(['chai'], function(chai) {
+require(['chai', 'lodash', 'moment'], function(chai, _, moment) {
   window.expect = chai.expect;
+  window._ = _;
+  window.moment = moment;
 });


### PR DESCRIPTION
I took a try at #141 "Auto-convert timestamp/date string attributes to Date objects" using an example provided by @xak2000

[Gist of Example](https://gist.github.com/xak2000/62ce767d871cf6d5e0f9)

My contribution extends the services template to include the dateTransformer factory from the example. The  template then conditionally injects the dateTransformer and adds a transformResponse to each resource that has at least one property that is defined as a date, passing the property name(s) to the transformer.

Concerns:
- Should there be a switch on the generator or some other backwards compatibility approach
- Introduces a requirement for lbServices consumers to have lodash and moment
- Is this the best way to get and array of property definition from within the template `meta.sharedClass.ctor.definition.rawProperties`
