### PR TITLE
Remove duplicate methods from service file

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -107,9 +107,18 @@ function buildScopes(models) {
 
 function buildScopesOfModel(models, modelName) {
   var modelClass = models[modelName];
+  var methodNames = [];
 
   modelClass.scopes = {};
-  modelClass.methods.forEach(function(method) {
+  modelClass.methods.forEach(function(method, idx) {
+    // Remove duplicate methods from model
+    if (methodNames.indexOf(method.fullName) > -1) {
+      modelClass.methods.splice(idx, 1);
+      return;
+    } else {
+      methodNames.push(method.fullName);
+    }
+    
     buildScopeMethod(models, modelName, method);
   });
 


### PR DESCRIPTION
If a remote method is defined in a model's JS file and in its JSON file, if you run lb-ng on the models, the angular sdk outputs an object with duplicate keys(one key from the JSON definition, one from the js implementation). This violates the 'use strict' declaration of the function, and causes the file not to load at all.

This commit removes subsequent re-definitions of a model's method, so that only the first definition is pushed to the angular template.  This is actually likely caused by an issue in Loopback, as duplicate methods shouldn't be allowed in a model in the first place, but this will allow lb-ng to generate a file that can run right now.

Actual example of Loopback model with duplicate method defined:

```
 methods:
     [ RestMethod {
         fullName: 'list.education',
         name: 'education',
         accepts: [],
         returns: [ { arg: 'list', type: [ 'any' ] } ],
         errors: [],
         description: 'List of education levels and descriptions',
         notes: undefined,
         documented: true,
         routes: [ { path: 'education', verb: 'get' } ] },
       RestMethod {
         fullName: 'list.education',
         name: 'education',
         accepts: [],
         returns: [ { arg: 'list', type: [ 'any' ] } ],
         errors: [],
         description: undefined,
         notes: undefined,
         documented: true,
         routes: [ { path: '/education', verb: 'get' } ] },
```

The first list.education is from the JSON model definition in list.json , the second is from the implementation in list.js