### PR TITLE
Linting generated code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-apidocs/loopback-core.js

--- a/apidocs/.eslintrc
+++ b/apidocs/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc",
+  "rules": {
+    "quotes": ["off"]
+  }
+}

--- a/apidocs/describe-builtin-models.js
+++ b/apidocs/describe-builtin-models.js
@@ -1,3 +1,4 @@
+/* eslint quotes: ["error", "single"] */
 var fs = require('fs');
 var path = require('path');
 

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -334,7 +334,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
         var key = propsPrefix + name;
         if (value == null) value = '';
         storage[key] = value;
-      } catch(err) {
+      } catch (err) {
         console.log('Cannot access local/session storage:', err);
       }
     }
@@ -418,7 +418,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
      * Get the header name that is used for sending the authentication token.
      */
     this.getAuthHeader = function() {
-       return authHeader;
+      return authHeader;
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "generate-loopback-core": "node ./apidocs/describe-builtin-models.js",
     "prepublish": "npm run generate-loopback-core",
     "test": "node ./test.e2e/test-server.js node node_modules/karma/bin/karma start --single-run  --browsers PhantomJS",
-    "posttest": "eslint ."
+    "lint": "eslint .",
+    "posttest": "npm run generate-loopback-core && npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
connect to #114

#### Things changed
- removed `.eslintignore` 
- added rule to allow double quote in `/apidocs` folder
- running lint on generated code upon npm test

chatted with @bajtos we agreed that code is likely to be minified, 
linting generated code's main purpose is just to catch bugs, 
no need to strictly enforcing coding style on generated code