### PR TITLE
Add option to leave out definitions for common modules + namespace models

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -54,6 +54,9 @@ module.exports = function generateServices(app, options) {
   options = extend({
     ngModuleName: 'lbServices',
     apiUrl: '/',
+    includeCommonModules: true,
+    namespaceModels: false,
+    namespaceDelimiter: '.',
   }, options);
 
   var models = describeModels(app, options);
@@ -67,13 +70,26 @@ module.exports = function generateServices(app, options) {
     moduleName: options.ngModuleName,
     models: models,
     urlBase: options.apiUrl.replace(/\/+$/, ''),
+    includeCommonModules: options.includeCommonModules,
   });
 };
+
+function getFormattedModelName(modelName, options) {
+  // Always capitalize first letter of model name
+  var resourceModelName = modelName[0].toUpperCase() + modelName.slice(1);
+
+  // Prefix with the module name and delimiter if namespacing is on
+  if (options.namespaceModels) {
+    resourceModelName = options.ngModuleName +
+      options.namespaceDelimiter + resourceModelName;
+  }
+  return resourceModelName;
+}
 
 function describeModels(app, options) {
   var result = {};
   app.handler('rest').adapter.getClasses().forEach(function(c) {
-    var name = c.name;
+    var name = getFormattedModelName(c.name, options);
     c.description = c.sharedClass.ctor.settings.description;
 
     if (!c.ctor) {

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -37,8 +37,6 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
 <% for (var modelName in models) {
      var meta = models[modelName];
-     // capitalize the model name
-     modelName = modelName[0].toUpperCase() + modelName.slice(1);
 -%>
 /**
  * @ngdoc object
@@ -300,7 +298,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       }]);
 
 <% } // for modelName in models -%>
-
+<% if (includeCommonModules) { %>
   module
   .factory('LoopBackAuth', function() {
     var props = ['accessTokenId', 'currentUserId', 'rememberMe'];
@@ -490,7 +488,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       return LoopBackResource;
     }];
   });
-<%
+<% } // end if (includeCommonModules)
+
 function getJsDocType(arg) {
   var type = arg.type == 'any' ? '*' : arg.type;
   if (!arg.required) type += '=';

--- a/test.e2e/given.js
+++ b/test.e2e/given.js
@@ -58,7 +58,9 @@ define(['angular', 'angularMocks', 'angularResource'], function(angular) {
    * ```
    */
   given.servicesForLoopBackApp = function(options, cb) {
-    options.name = generateUniqueServiceName(options.name);
+    if (!options.name) {
+      options.name = generateUniqueServiceName(options.name);
+    }
 
     var promise = callSetup(options)
       .then(function(config) { return config.servicesUrl; })

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -1044,6 +1044,150 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
       });
     });
 
+    describe('$resource generated with includeCommonModules:false', function() {
+      var $injector;
+      before(function() {
+        return given.servicesForLoopBackApp(
+          {
+            models: {
+              Product: {
+                properties: {
+                  name: 'string',
+                  price: { type: 'number' },
+                },
+              },
+            },
+            includeCommonModules: false,
+          })
+          .then(function(createInjector) {
+            $injector = createInjector();
+          });
+      });
+
+      it('does not have "LoopBackAuth module"', function() {
+        expect(function() {
+          $injector.get('LoopBackAuth');
+        }).to.throw(/Unknown provider/);
+      });
+
+      it('does not have "LoopBackResource provider"', function() {
+        expect(function() {
+          $injector.get('LoopBackResource');
+        }).to.throw(/Unknown provider/);
+      });
+
+      it('does not have "LoopBackAuthRequestInterceptor module"',
+      function() {
+        expect(function() {
+          $injector.get('LoopBackAuthRequestInterceptor');
+        }).to.throw(/Unknown provider/);
+      });
+    });
+
+    describe('$resource generated with includeCommonModules:true (by default)',
+    function() {
+      var $injector;
+      before(function() {
+        return given.servicesForLoopBackApp(
+          {
+            models: {
+              Product: {
+                properties: {
+                  name: 'string',
+                  price: { type: 'number' },
+                },
+              },
+            },
+          })
+          .then(function(createInjector) {
+            $injector = createInjector();
+          });
+      });
+
+      it('has "LoopBackAuth module"', function() {
+        expect(function() {
+          $injector.get('LoopBackAuth');
+        }).to.not.throw();
+      });
+
+      it('has "LoopBackResource provider"', function() {
+        expect(function() {
+          $injector.get('LoopBackResource');
+        }).to.not.throw();
+      });
+
+      it('has "LoopBackAuthRequestInterceptor module"',
+      function() {
+        expect(function() {
+          $injector.get('LoopBackAuthRequestInterceptor');
+        }).to.not.throw();
+      });
+    });
+
+    describe('$resource generated with namespaceModels:true', function() {
+      var $injector;
+      before(function() {
+        return given.servicesForLoopBackApp(
+          {
+            models: {
+              Product: {
+                properties: {
+                  name: 'string',
+                  price: { type: 'number' },
+                },
+              },
+            },
+            name: 'lbServices',
+            namespaceModels: true,
+          })
+          .then(function(createInjector) {
+            $injector = createInjector();
+          });
+      });
+
+      it('defines the "Product" model as "lbServices.Product"', function() {
+        expect(function() {
+          $injector.get('Product');
+        }).to.throw(/Unknown provider/);
+        expect(function() {
+          $injector.get('lbServices.Product');
+        }).to.not.throw();
+      });
+    });
+
+    describe('$resource generated with namespaceModels:true and ' +
+    'namespaceDelimiter:_', function() {
+      var $injector;
+      before(function() {
+        return given.servicesForLoopBackApp(
+          {
+            models: {
+              Product: {
+                properties: {
+                  name: 'string',
+                  price: { type: 'number' },
+                },
+              },
+            },
+            name: 'lbServices',
+            namespaceModels: true,
+            namespaceDelimiter: '_',
+          })
+          .then(function(createInjector) {
+            $injector = createInjector();
+          });
+      });
+
+      it('defines the "Product" model as "lbServices.Product"', function() {
+        expect(function() {
+          $injector.get('Product');
+        }).to.throw(/Unknown provider/);
+        expect(function() {
+          $injector.get('lbServices_Product');
+        }).to.not.throw();
+      });
+    });
+
     describe('for models with belongsTo relation', function() {
       var $injector, Town, Country, testData;
       before(function() {


### PR DESCRIPTION
When connecting to several LoopBack APIs from an Angular app, multiple definitions of LoopBackAuth and LoopBackResource will 'step on' each other, resulting in unpredictable behavior.

This change keeps the default behavior consistent, but will omit the module block that generates the LoopBackAuth, LoopBackAuthRequestInterceptor, and LoopBackResource components if a fourth parameter (excludeCommonModules) is set to 'true' when generateServices is called.

This will enable loopback-sdk-angular to more seamlessly be used with multiple-API architectures, without having to manually delete sections of code generated by the SDK.