### PR TITLE
Update deprecated remoting metadata functions

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -73,7 +73,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       'LoopBackResource', 'LoopBackAuth', '$injector',
       function(Resource, LoopBackAuth, $injector) {
         var R = Resource(
-        urlBase + <%-: meta.ctor.getFullPath() | q %>,
+        urlBase + <%-: meta.ctor.getEndpoints()[0].fullPath | q %>,
 <% /*
         Constructor arguments are hardcoded for now.
         We should generate it from sharedCtor.accepts instead.
@@ -123,8 +123,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 <%   }); //action.params.foreach -%>
               },
 <% } -%>
-              url: urlBase + <%-: action.getFullPath() | q %>,
-              method: <%-: action.getHttpMethod() | q %>,
+              url: urlBase + <%-: action.getEndpoints()[0].fullPath | q %>,
+              method: <%-: action.getEndpoints()[0].verb | q %>,
             },
 <% }); // meta.methods.foreach -%>
 <% if (meta.isUser) { -%>
@@ -529,7 +529,7 @@ action.description =  '<em>\n' +
 <%
 var params = action.accepts;
 var postData;
-if (action.getHttpMethod() == 'POST' || action.getHttpMethod() == 'PUT') {
+if (action.getEndpoints()[0].verb == 'POST' || action.getEndpoints()[0].verb == 'PUT') {
   params = params.filter(function(arg) {
     return arg.http && (arg.http.source == 'query' || arg.http.source == 'path');
   });


### PR DESCRIPTION
Remove deprecation warning from `getFullPath()` and `getHttpMethod()`

See https://github.com/strongloop/strong-remoting/pull/305
right now it gives deprecation warning 
```coffeescript
> npm run generate-loopback-core && npm run lint


> loopback-sdk-angular@1.8.0 generate-loopback-core /Users/davidcheung/node-web/loopback-sdk-angular
> node ./apidocs/describe-builtin-models.js

Generating API docs for LoopBack built-in models.
loopback deprecated loopback.compress is deprecated. Use `require('compression');` instead. apidocs/describe-builtin-models.js:32:23
  added persisted model ACL
  added persisted model AccessToken
  added persisted model Application
  added persisted model Change
  added persisted model Checkpoint
  added model Email
  added persisted model Role
  added persisted model RoleMapping
  added persisted model Scope
  added persisted model User
strong-remoting deprecated getFullPath() is deprecated, use getEndpoints()[0].fullPath instead. eval at <anonymous> (/Users/davidcheung/node-web/loopback-sdk-angular/node_modules/ejs/lib/ejs.js:242:14), <anonymous>:36:314
strong-remoting deprecated getHttpMethod() is deprecated, use getEndpoints()[0].verb instead. eval at <anonymous> (/Users/davidcheung/node-web/loopback-sdk-angular/node_modules/ejs/lib/ejs.js:242:14), <anonymous>:94:12
strong-remoting deprecated getFullPath() is deprecated, use getEndpoints()[0].fullPath instead. eval at <anonymous> (/Users/davidcheung/node-web/loopback-sdk-angular/node_modules/ejs/lib/ejs.js:242:14), <anonymous>:42:140
strong-remoting deprecated getHttpMethod() is deprecated, use getEndpoints()[0].verb instead. eval at <anonymous> (/Users/davidcheung/node-web/loopback-sdk-angular/node_modules/ejs/lib/ejs.js:242:14), <anonymous>:42:228
strong-remoting deprecated getHttpMethod() is deprecated, use getEndpoints()[0].verb instead. eval at <anonymous> (/Users/davidcheung/node-web/loopback-sdk-angular/node_modules/ejs/lib/ejs.js:242:14), <anonymous>:94:48
Done: /Users/davidcheung/node-web/loopback-sdk-angular/apidocs/loopback-core.js
```



@0candy PTAL
/cc @Amir-61 @bajtos 
