### PR TITLE
Update dependency and test command for PhantomJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "karma-junit-reporter": "^0.3.8",
     "karma-mocha": "^0.2.1",
     "karma-mocha-reporter": "^1.1.5",
-    "karma-phantomjs-launcher": "^0.2.3",
+    "karma-phantomjs-launcher": "^1.0.1",
     "karma-requirejs": "^0.2.1",
     "loopback": "^2.0",
     "loopback-datasource-juggler": "^2.0",
     "mocha": "~1.18.0",
     "morgan": "^1.2",
-    "phantomjs": "^1.9.19",
+    "phantomjs-prebuilt": "^2.1.7",
     "requirejs": "^2.1.9"
   }
 }


### PR DESCRIPTION
connected to strongloop/loopback-sdk-angular#215

The resolution to an error when running "npm test" is to update the PhantomJS dependency to PhantomJS2.

## Background

Current angular dependency is defined:
  "angular": "^1.4.9"

With the release of angular 1.5 there are errors loading angular in PhantomJS that affect this repo's default test command.

Original Issue not addressed in PhantomJS 1.0: https://github.com/ariya/phantomjs/issues/10522

Recent discussion specific to angular 1.5: https://github.com/angular/angular.js/issues/13794

Error Message:
> PhantomJS 1.9.8 (Windows 8 0.0.0) ERROR
>   Error: [$injector:modulerr] Failed to instantiate module ng due to:
>   TypeError: 'undefined' is not an object (evaluating 'Function.prototype.bind.apply')