### PR TITLE
Add modelsToIgnore option

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -58,6 +58,7 @@ module.exports = function generateServices(app, options) {
     includeCommonModules: true,
     namespaceModels: false,
     namespaceDelimiter: '.',
+    modelsToIgnore: [],
   }, options);
 
   var models = describeModels(app, options);
@@ -89,9 +90,18 @@ function getFormattedModelName(modelName, options) {
 
 function describeModels(app, options) {
   var result = {};
+  var modelsToIgnore = options.modelsToIgnore;
+
   app.handler('rest').adapter.getClasses().forEach(function(c) {
     var name = getFormattedModelName(c.name, options);
     c.description = c.sharedClass.ctor.settings.description;
+
+    if (modelsToIgnore.indexOf(name) >= 0) {
+      // Skip classes that are provided in options.modelsToIgnore array
+      // We don't want to publish these models in angular app
+      g.warn('Skipping %j model as it is not to be published', name);
+      return;
+    }
 
     if (!c.ctor) {
       // Skip classes that don't have a shared ctor

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -1268,6 +1268,32 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
         });
       });
     });
+
+    describe('$resource not generated for ignored models', function() {
+      var $injector, IgnoredModel;
+      before(function() {
+        return  given.servicesForLoopBackApp({
+          models: {
+            IgnoredModel: {
+              properties: {
+                name: String,
+                required: true,
+              },
+            },
+          },
+          modelsToIgnore: ['IgnoredModel'],
+        })
+        .then(function(createInjector) {
+          $injector = createInjector();
+        });
+      });
+
+      it('model "IgnoredModel" should be undefined', function() {
+        IgnoredModel = $injector.has('IgnoredModel');
+        console.log('IgnoredModel', IgnoredModel);
+        expect(IgnoredModel).to.be.false;
+      });
+    });
   });
 
   function propGetter(name) {

--- a/test.e2e/test-server.js
+++ b/test.e2e/test-server.js
@@ -154,7 +154,8 @@ function generateService(generator, lbApp, apiUrl, opts) {
   if (opts.includeSchema !== undefined ||
       opts.includeCommonModules !== undefined ||
       opts.namespaceModels !== undefined ||
-      opts.namespaceDelimiter !== undefined) {
+      opts.namespaceDelimiter !== undefined ||
+      opts.modelsToIgnore !== undefined) {
     // the new options-based API
 
     // build options object for new options-based API


### PR DESCRIPTION
- Added a new parameter named as `modelsToIgnore` which stores a list of models that are to be prevented from being published in loopback angular SDK
- Added tests for testing `modelToIgnore` feature


This PR is an update for #224 
cc @bajtos @pulkitsinghal