### PR TITLE
getEndPoints() compatibility for strong-remoting

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -12,6 +12,28 @@ ejs.filters.q = function(obj) {
   return JSON.stringify(obj, null, 2);
 };
 
+ejs.filters.getPropertyOfFirstEndpoint = function(remoteObj, item) {
+  return getPropertyOfFirstEndpoint(remoteObj, item);
+};
+
+// this method is added to support both flavors of the getEndPoints method
+// in strong-remoting 2.x methods `getHttpMethod()` and `getFullPath()` were used
+// in strong-remoting 3.x we have deprecated those methods in favor of getEndPoints()
+function getPropertyOfFirstEndpoint(remoteObj, item) {
+  // strong-remoting 3.x
+  if (typeof remoteObj.getEndpoints == 'function') {
+    return remoteObj.getEndpoints()[0][item];
+  } else { // strong-remoting 2.x
+    if (item == 'verb') {
+      return remoteObj.getHttpMethod();
+    } else if (item == 'fullPath') {
+      return remoteObj.getFullPath();
+    } else {
+      throw new Error(g.f('Unsupported endpoint property: %s'));
+    }
+  }
+}
+
 /**
  * Generate Angular $resource services for the given loopback application.
  *
@@ -73,6 +95,9 @@ module.exports = function generateServices(app, options) {
     models: models,
     urlBase: options.apiUrl.replace(/\/+$/, ''),
     includeCommonModules: options.includeCommonModules,
+    helpers: {
+      getPropertyOfFirstEndpoint: getPropertyOfFirstEndpoint,
+    },
   });
 };
 

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -71,7 +71,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       'LoopBackResource', 'LoopBackAuth', '$injector',
       function(Resource, LoopBackAuth, $injector) {
         var R = Resource(
-        urlBase + <%-: meta.ctor.getEndpoints()[0].fullPath | q %>,
+        urlBase + <%-: meta.ctor | getPropertyOfFirstEndpoint:'fullPath' | q %>,
 <% /*
         Constructor arguments are hardcoded for now.
         We should generate it from sharedCtor.accepts instead.
@@ -121,8 +121,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 <%   }); //action.params.foreach -%>
               },
 <% } -%>
-              url: urlBase + <%-: action.getEndpoints()[0].fullPath | q %>,
-              method: <%-: action.getEndpoints()[0].verb | q %>,
+              url: urlBase + <%-: action | getPropertyOfFirstEndpoint:'fullPath' | q  %>,
+              method: <%-: action | getPropertyOfFirstEndpoint:'verb' | q %>,
             },
 <% }); // meta.methods.foreach -%>
 <% if (meta.isUser) { -%>
@@ -528,7 +528,8 @@ action.description =  '<em>\n' +
 <%
 var params = action.accepts;
 var postData;
-if (action.getEndpoints()[0].verb == 'POST' || action.getEndpoints()[0].verb == 'PUT') {
+var actionHttpMethod = helpers.getPropertyOfFirstEndpoint(action, 'verb');
+if (['POST', 'PUT'].indexOf(actionHttpMethod) != -1) {
   params = params.filter(function(arg) {
     return arg.http && (arg.http.source == 'query' || arg.http.source == 'path');
   });


### PR DESCRIPTION
fixes strongloop/loopback-sdk-angular/issues/236
in strong-remoting 2.x methods `getHttpMethod()` and `getFullPath()` were used
in strong-remoting 3.x we have deprecated those methods in favor of getEndPoints()
this patch is so users using newer SDK can still choose to use old strong-remoting
the change was introduced in strongloop/loopback-sdk-angular/pull/229