### PR TITLE
test: array descriptions for remoteMethods

### DIFF
--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -471,6 +471,50 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
       });
     });
 
+    describe('$resource remoteMethod with array descriptions', function() {
+      var $injector;
+      before(function() {
+        return given.servicesForLoopBackApp(
+          {
+            models: {
+              'remotable': {},
+            },
+            setupFn: (function(app, cb) {
+              var Remotable = app.models.Remotable;
+              Remotable.arrayDescription = function(cb) {
+                cb(null, {});
+              };
+              Remotable.remoteMethod(
+                'arrayDescription', {
+                  description: ['hello ', 'world'],
+                  http: { path: '/arrayDescription', verb: 'POST' },
+                  accepts: {
+                    arg: 'data',
+                    type: 'string',
+                    description: ['foo', 'bar'],
+                  },
+                  returns: {
+                    arg: 'data',
+                    type: 'string',
+                    description: ['foo', 'bar'],
+                  },
+                }
+              );
+              cb();
+            }).toString(),
+          })
+          .then(function(createInjector) {
+            $injector = createInjector();
+          });
+      });
+      it('has a client method with array description', function() {
+        var Remotable = $injector.get('Remotable');
+        var methodNames = Object.keys(Remotable);
+        console.log('methods', methodNames);
+        expect(methodNames).to.include.members(['arrayDescription']);
+      });
+    });
+
     describe('$resource for model with custom scope-like methods', function() {
       var $injector;
       before(function() {


### PR DESCRIPTION
verify fixes https://github.com/strongloop/loopback-sdk-angular/issues/161
remoteMethods' accept args with array description was broken before,
and accidentially fixed in f56b103da4ca7ab0e311402a814d18e49db192ce
when adding eslint by concats a space with the array, which performs
a toString on that array, to make `String.replace()` callable.
adding a test case with array to prevent future regression