### PR TITLE
adding the model suffix

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -79,6 +79,7 @@ module.exports = function generateServices(app, options) {
     apiUrl: '/',
     includeCommonModules: true,
     namespaceModels: false,
+    loopbackModelSuffix: '',
     namespaceDelimiter: '.',
     modelsToIgnore: [],
   }, options);
@@ -93,6 +94,7 @@ module.exports = function generateServices(app, options) {
   return ejs.render(servicesTemplate, {
     moduleName: options.ngModuleName,
     models: models,
+    loopbackModelSuffix: options.loopbackModelSuffix,
     urlBase: options.apiUrl.replace(/\/+$/, ''),
     includeCommonModules: options.includeCommonModules,
     helpers: {

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -68,9 +68,9 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
   module.factory(
     <%-: modelName | q %>,
     [
-      'LoopBackResource', 'LoopBackAuth', '$injector', '$q',
-      function(LoopBackResource, LoopBackAuth, $injector, $q) {
-        var R = LoopBackResource(
+      'LoopBack<%-: loopbackModelSuffix%>Resource', 'LoopBack<%-: loopbackModelSuffix%>Auth', '$injector', '$q',
+      function(LoopBack<%-: loopbackModelSuffix%>Resource, LoopBack<%-: loopbackModelSuffix%>Auth, $injector, $q) {
+        var R = LoopBack<%-: loopbackModelSuffix%>Resource(
         urlBase + <%-: meta.ctor | getPropertyOfFirstEndpoint:'fullPath' | q %>,
 <% /*
         Constructor arguments are hardcoded for now.
@@ -92,24 +92,24 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
               interceptor: {
                 response: function(response) {
                   var accessToken = response.data;
-                  LoopBackAuth.setUser(
+                  LoopBack<%-: loopbackModelSuffix%>Auth.setUser(
                     accessToken.id, accessToken.userId, accessToken.user);
-                  LoopBackAuth.rememberMe =
+                  LoopBack<%-: loopbackModelSuffix%>Auth.rememberMe =
                     response.config.params.rememberMe !== false;
-                  LoopBackAuth.save();
+                  LoopBack<%-: loopbackModelSuffix%>Auth.save();
                   return response.resource;
                 },
               },
 <% } else if (meta.isUser && methodName === 'logout') { -%>
               interceptor: {
                 response: function(response) {
-                  LoopBackAuth.clearUser();
-                  LoopBackAuth.clearStorage();
+                  LoopBack<%-: loopbackModelSuffix%>Auth.clearUser();
+                  LoopBack<%-: loopbackModelSuffix%>Auth.clearStorage();
                   return response.resource;
                 },
                 responseError: function(responseError) {
-                  LoopBackAuth.clearUser();
-                  LoopBackAuth.clearStorage();
+                  LoopBack<%-: loopbackModelSuffix%>Auth.clearUser();
+                  LoopBack<%-: loopbackModelSuffix%>Auth.clearStorage();
                   return responseError.resource;
                 },
               },
@@ -152,19 +152,19 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
               method: 'GET',
               params: {
                 id: function() {
-                  var id = LoopBackAuth.currentUserId;
+                  var id = LoopBack<%-: loopbackModelSuffix%>Auth.currentUserId;
                   if (id == null) id = '__anonymous__';
                   return id;
                 },
               },
               interceptor: {
                 response: function(response) {
-                  LoopBackAuth.currentUserData = response.data;
+                  LoopBack<%-: loopbackModelSuffix%>Auth.currentUserData = response.data;
                   return response.resource;
                 },
                 responseError: function(responseError) {
-                  LoopBackAuth.clearUser();
-                  LoopBackAuth.clearStorage();
+                  LoopBack<%-: loopbackModelSuffix%>Auth.clearUser();
+                  LoopBack<%-: loopbackModelSuffix%>Auth.clearStorage();
                   return $q.reject(responseError);
                 },
               },
@@ -203,7 +203,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
          * @returns {Object} A <%- modelName %> instance.
          */
         R.getCachedCurrent = function() {
-          var data = LoopBackAuth.currentUserData;
+          var data = LoopBack<%-: loopbackModelSuffix%>Auth.currentUserData;
           return data ? new R(data) : null;
         };
 
@@ -226,7 +226,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
          * @returns {Object} Id of the currently logged-in user or null.
          */
         R.getCurrentId = function() {
-          return LoopBackAuth.currentUserId;
+          return LoopBack<%-: loopbackModelSuffix%>Auth.currentUserId;
         };
 <% } -%>
 
@@ -305,11 +305,11 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 <% } // for modelName in models -%>
 <% if (includeCommonModules) { %>
   module
-  .factory('LoopBackAuth', function() {
+  .factory('LoopBack<%-: loopbackModelSuffix%>Auth', function() {
     var props = ['accessTokenId', 'currentUserId', 'rememberMe'];
     var propsPrefix = '$LoopBack$';
 
-    function LoopBackAuth() {
+    function LoopBack<%-: loopbackModelSuffix%>Auth() {
       var self = this;
       props.forEach(function(name) {
         self[name] = load(name);
@@ -317,7 +317,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       this.currentUserData = null;
     }
 
-    LoopBackAuth.prototype.save = function() {
+    LoopBack<%-: loopbackModelSuffix%>Auth.prototype.save = function() {
       var self = this;
       var storage = this.rememberMe ? localStorage : sessionStorage;
       props.forEach(function(name) {
@@ -325,26 +325,26 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       });
     };
 
-    LoopBackAuth.prototype.setUser = function(accessTokenId, userId, userData) {
+    LoopBack<%-: loopbackModelSuffix%>Auth.prototype.setUser = function(accessTokenId, userId, userData) {
       this.accessTokenId = accessTokenId;
       this.currentUserId = userId;
       this.currentUserData = userData;
     };
 
-    LoopBackAuth.prototype.clearUser = function() {
+    LoopBack<%-: loopbackModelSuffix%>Auth.prototype.clearUser = function() {
       this.accessTokenId = null;
       this.currentUserId = null;
       this.currentUserData = null;
     };
 
-    LoopBackAuth.prototype.clearStorage = function() {
+    LoopBack<%-: loopbackModelSuffix%>Auth.prototype.clearStorage = function() {
       props.forEach(function(name) {
         save(sessionStorage, name, null);
         save(localStorage, name, null);
       });
     };
 
-    return new LoopBackAuth();
+    return new LoopBack<%-: loopbackModelSuffix%>Auth();
 
     // Note: LocalStorage converts the value to string
     // We are using empty string as a marker for null/undefined values.
@@ -364,10 +364,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
     }
   })
   .config(['$httpProvider', function($httpProvider) {
-    $httpProvider.interceptors.push('LoopBackAuthRequestInterceptor');
+    $httpProvider.interceptors.push('LoopBack<%-: loopbackModelSuffix%>AuthRequestInterceptor');
   }])
-  .factory('LoopBackAuthRequestInterceptor', ['$q', 'LoopBackAuth',
-    function($q, LoopBackAuth) {
+  .factory('LoopBack<%-: loopbackModelSuffix%>AuthRequestInterceptor', ['$q', 'LoopBack<%-: loopbackModelSuffix%>Auth',
+    function($q, LoopBack<%-: loopbackModelSuffix%>Auth) {
       return {
         'request': function(config) {
           // filter out external requests
@@ -376,8 +376,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
             return config;
           }
 
-          if (LoopBackAuth.accessTokenId) {
-            config.headers[authHeader] = LoopBackAuth.accessTokenId;
+          if (LoopBack<%-: loopbackModelSuffix%>Auth.accessTokenId) {
+            config.headers[authHeader] = LoopBack<%-: loopbackModelSuffix%>Auth.accessTokenId;
           } else if (config.__isGetCurrentUser__) {
             // Return a stub 401 error for User.getCurrent() when
             // there is no user logged in
@@ -396,10 +396,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
   /**
    * @ngdoc object
-   * @name <%-: moduleName %>.LoopBackResourceProvider
-   * @header <%-: moduleName %>.LoopBackResourceProvider
+   * @name <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider
+   * @header <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider
    * @description
-   * Use `LoopBackResourceProvider` to change the global configuration
+   * Use `LoopBack<%-: loopbackModelSuffix%>ResourceProvider` to change the global configuration
    * settings used by all models. Note that the provider is available
    * to Configuration Blocks only, see
    * {@link https://docs.angularjs.org/guide/module#module-loading-dependencies Module Loading & Dependencies}
@@ -409,16 +409,16 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
    *
    * ```js
    * angular.module('app')
-   *  .config(function(LoopBackResourceProvider) {
-   *     LoopBackResourceProvider.setAuthHeader('X-Access-Token');
+   *  .config(function(LoopBack<%-: loopbackModelSuffix%>ResourceProvider) {
+   *     LoopBack<%-: loopbackModelSuffix%>ResourceProvider.setAuthHeader('X-Access-Token');
    *  });
    * ```
    */
-  .provider('LoopBackResource', function LoopBackResourceProvider() {
+  .provider('LoopBack<%-: loopbackModelSuffix%>Resource', function LoopBack<%-: loopbackModelSuffix%>ResourceProvider() {
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#setAuthHeader
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider#setAuthHeader
+     * @methodOf <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider
      * @param {string} header The header name to use, e.g. `X-Access-Token`
      * @description
      * Configure the REST transport to use a different header for sending
@@ -431,8 +431,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#getAuthHeader
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider#getAuthHeader
+     * @methodOf <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider
      * @description
      * Get the header name that is used for sending the authentication token.
      */
@@ -442,8 +442,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#setUrlBase
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider#setUrlBase
+     * @methodOf <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider
      * @param {string} url The URL to use, e.g. `/api` or `//example.com/api`.
      * @description
      * Change the URL of the REST API server. By default, the URL provided
@@ -456,8 +456,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#getUrlBase
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider#getUrlBase
+     * @methodOf <%-: moduleName %>.LoopBack<%-: loopbackModelSuffix%>ResourceProvider
      * @description
      * Get the URL of the REST API server. The URL provided
      * to the code generator (`lb-ng` or `grunt-loopback-sdk-angular`) is used.
@@ -467,7 +467,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
     };
 
     this.$get = ['$resource', function($resource) {
-      var LoopBackResource = function(url, params, actions) {
+      var LoopBack<%-: loopbackModelSuffix%>Resource = function(url, params, actions) {
         var resource = $resource(url, params, actions);
 
         // Angular always calls POST on $save()
@@ -482,15 +482,15 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
         return resource;
       };
 
-      LoopBackResource.getUrlBase = function() {
+      LoopBack<%-: loopbackModelSuffix%>Resource.getUrlBase = function() {
         return urlBase;
       };
 
-      LoopBackResource.getAuthHeader = function() {
+      LoopBack<%-: loopbackModelSuffix%>Resource.getAuthHeader = function() {
         return authHeader;
       };
 
-      return LoopBackResource;
+      return LoopBack<%-: loopbackModelSuffix%>Resource;
     }];
   });
 <% } // end if (includeCommonModules)


### PR DESCRIPTION
Add a suffix to the core loopback models to allow multiple lb services to exist on the same client, pointing to APIs on different services.

The core models start with 'LoopBack'. The suffix is appended to the LoopBack part of the name while still appending its class after the suffix.

For example if the suffix is Accounts, then the generated core loopback models are: LoopBackAccountsResource, LoopBackAccountsAuth, LoopBackAccountsResourceProvider, LoopBackAccountsAuthRequestInterceptor.
See Issue #250
