### PR TITLE
Add new option namespaceCommonModels

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -79,6 +79,7 @@ module.exports = function generateServices(app, options) {
     apiUrl: '/',
     includeCommonModules: true,
     namespaceModels: false,
+    namespaceCommonModels: false,
     namespaceDelimiter: '.',
     modelsToIgnore: [],
   }, options);
@@ -90,11 +91,27 @@ module.exports = function generateServices(app, options) {
     { encoding: 'utf-8' }
   );
 
+  var commonModelPrefix = 'LoopBack';
+  if (options.namespaceCommonModels) {
+    commonModelPrefix = options.ngModuleName + options.namespaceDelimiter;
+    if (options.namespaceDelimiter === '.') {
+      throw new Error('Unsupported delimiter \'.\' for ' +
+        'namespacing common models.');
+    }
+    commonModelPrefix = commonModelPrefix.replace(/\./g,
+      options.namespaceDelimiter);
+  }
+
   return ejs.render(servicesTemplate, {
     moduleName: options.ngModuleName,
     models: models,
+    commonAuth: commonModelPrefix + 'Auth',
+    commonAuthRequestInterceptor: commonModelPrefix + 'AuthRequestInterceptor',
+    commonResource: commonModelPrefix + 'Resource',
+    commonResourceProvider: commonModelPrefix + 'ResourceProvider',
     urlBase: options.apiUrl.replace(/\/+$/, ''),
     includeCommonModules: options.includeCommonModules,
+
     helpers: {
       getPropertyOfFirstEndpoint: getPropertyOfFirstEndpoint,
     },

--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -20,8 +20,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
     var m = url.match(/^(?:https?:)?\/\/([^\/]+)/);
     return m ? m[1] : null;
   }
-
-  var urlBaseHost = getHost(urlBase) || location.host;
+  // need to use the urlBase as the base to handle multiple
+  // loopback servers behind a proxy/gateway where the host
+  // would be the same.
+  var urlBaseHost = getHost(urlBase) ? urlBase : location.host;
 
 /**
  * @ngdoc overview
@@ -68,9 +70,9 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
   module.factory(
     <%-: modelName | q %>,
     [
-      'LoopBackResource', 'LoopBackAuth', '$injector', '$q',
-      function(LoopBackResource, LoopBackAuth, $injector, $q) {
-        var R = LoopBackResource(
+      '<%-: commonResource%>', '<%-: commonAuth%>', '$injector', '$q',
+      function(<%-: commonResource%>, <%-: commonAuth%>, $injector, $q) {
+        var R = <%-: commonResource%>(
         urlBase + <%-: meta.ctor | getPropertyOfFirstEndpoint:'fullPath' | q %>,
 <% /*
         Constructor arguments are hardcoded for now.
@@ -92,24 +94,24 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
               interceptor: {
                 response: function(response) {
                   var accessToken = response.data;
-                  LoopBackAuth.setUser(
+                  <%-: commonAuth%>.setUser(
                     accessToken.id, accessToken.userId, accessToken.user);
-                  LoopBackAuth.rememberMe =
+                  <%-: commonAuth%>.rememberMe =
                     response.config.params.rememberMe !== false;
-                  LoopBackAuth.save();
+                  <%-: commonAuth%>.save();
                   return response.resource;
                 },
               },
 <% } else if (meta.isUser && methodName === 'logout') { -%>
               interceptor: {
                 response: function(response) {
-                  LoopBackAuth.clearUser();
-                  LoopBackAuth.clearStorage();
+                  <%-: commonAuth%>.clearUser();
+                  <%-: commonAuth%>.clearStorage();
                   return response.resource;
                 },
                 responseError: function(responseError) {
-                  LoopBackAuth.clearUser();
-                  LoopBackAuth.clearStorage();
+                  <%-: commonAuth%>.clearUser();
+                  <%-: commonAuth%>.clearStorage();
                   return responseError.resource;
                 },
               },
@@ -152,19 +154,19 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
               method: 'GET',
               params: {
                 id: function() {
-                  var id = LoopBackAuth.currentUserId;
+                  var id = <%-: commonAuth%>.currentUserId;
                   if (id == null) id = '__anonymous__';
                   return id;
                 },
               },
               interceptor: {
                 response: function(response) {
-                  LoopBackAuth.currentUserData = response.data;
+                  <%-: commonAuth%>.currentUserData = response.data;
                   return response.resource;
                 },
                 responseError: function(responseError) {
-                  LoopBackAuth.clearUser();
-                  LoopBackAuth.clearStorage();
+                  <%-: commonAuth%>.clearUser();
+                  <%-: commonAuth%>.clearStorage();
                   return $q.reject(responseError);
                 },
               },
@@ -209,7 +211,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
          * @returns {Object} A <%- modelName %> instance.
          */
         R.getCachedCurrent = function() {
-          var data = LoopBackAuth.currentUserData;
+          var data = <%-: commonAuth%>.currentUserData;
           return data ? new R(data) : null;
         };
 
@@ -232,7 +234,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
          * @returns {Object} Id of the currently logged-in user or null.
          */
         R.getCurrentId = function() {
-          return LoopBackAuth.currentUserId;
+          return <%-: commonAuth%>.currentUserId;
         };
 <% } -%>
 
@@ -311,11 +313,11 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 <% } // for modelName in models -%>
 <% if (includeCommonModules) { %>
   module
-  .factory('LoopBackAuth', function() {
+  .factory('<%-: commonAuth%>', function() {
     var props = ['accessTokenId', 'currentUserId', 'rememberMe'];
     var propsPrefix = '$LoopBack$';
 
-    function LoopBackAuth() {
+    function <%-: commonAuth%>() {
       var self = this;
       props.forEach(function(name) {
         self[name] = load(name);
@@ -323,7 +325,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       this.currentUserData = null;
     }
 
-    LoopBackAuth.prototype.save = function() {
+    <%-: commonAuth%>.prototype.save = function() {
       var self = this;
       var storage = this.rememberMe ? localStorage : sessionStorage;
       props.forEach(function(name) {
@@ -331,26 +333,26 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       });
     };
 
-    LoopBackAuth.prototype.setUser = function(accessTokenId, userId, userData) {
+    <%-: commonAuth%>.prototype.setUser = function(accessTokenId, userId, userData) {
       this.accessTokenId = accessTokenId;
       this.currentUserId = userId;
       this.currentUserData = userData;
     };
 
-    LoopBackAuth.prototype.clearUser = function() {
+    <%-: commonAuth%>.prototype.clearUser = function() {
       this.accessTokenId = null;
       this.currentUserId = null;
       this.currentUserData = null;
     };
 
-    LoopBackAuth.prototype.clearStorage = function() {
+    <%-: commonAuth%>.prototype.clearStorage = function() {
       props.forEach(function(name) {
         save(sessionStorage, name, null);
         save(localStorage, name, null);
       });
     };
 
-    return new LoopBackAuth();
+    return new <%-: commonAuth%>();
 
     // Note: LocalStorage converts the value to string
     // We are using empty string as a marker for null/undefined values.
@@ -370,20 +372,20 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
     }
   })
   .config(['$httpProvider', function($httpProvider) {
-    $httpProvider.interceptors.push('LoopBackAuthRequestInterceptor');
+    $httpProvider.interceptors.push('<%-: commonAuthRequestInterceptor%>');
   }])
-  .factory('LoopBackAuthRequestInterceptor', ['$q', 'LoopBackAuth',
-    function($q, LoopBackAuth) {
+  .factory('<%-: commonAuthRequestInterceptor%>', ['$q', '<%-: commonAuth%>',
+    function($q, <%-: commonAuth%>) {
       return {
         'request': function(config) {
           // filter out external requests
           var host = getHost(config.url);
-          if (host && host !== urlBaseHost) {
+          if (host && config.url.indexOf(urlBaseHost) === -1) {
             return config;
           }
 
-          if (LoopBackAuth.accessTokenId) {
-            config.headers[authHeader] = LoopBackAuth.accessTokenId;
+          if (<%-: commonAuth%>.accessTokenId) {
+            config.headers[authHeader] = <%-: commonAuth%>.accessTokenId;
           } else if (config.__isGetCurrentUser__) {
             // Return a stub 401 error for User.getCurrent() when
             // there is no user logged in
@@ -402,10 +404,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
   /**
    * @ngdoc object
-   * @name <%-: moduleName %>.LoopBackResourceProvider
-   * @header <%-: moduleName %>.LoopBackResourceProvider
+   * @name <%-: moduleName %>.<%-: commonResourceProvider%>
+   * @header <%-: moduleName %>.<%-: commonResourceProvider%>
    * @description
-   * Use `LoopBackResourceProvider` to change the global configuration
+   * Use `<%-: commonResourceProvider%>` to change the global configuration
    * settings used by all models. Note that the provider is available
    * to Configuration Blocks only, see
    * {@link https://docs.angularjs.org/guide/module#module-loading-dependencies Module Loading & Dependencies}
@@ -415,16 +417,16 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
    *
    * ```js
    * angular.module('app')
-   *  .config(function(LoopBackResourceProvider) {
-   *     LoopBackResourceProvider.setAuthHeader('X-Access-Token');
+   *  .config(function(<%-: commonResourceProvider%>) {
+   *     <%-: commonResourceProvider%>.setAuthHeader('X-Access-Token');
    *  });
    * ```
    */
-  .provider('LoopBackResource', function LoopBackResourceProvider() {
+  .provider('<%-: commonResource%>', function <%-: commonResourceProvider%>() {
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#setAuthHeader
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.<%-: commonResourceProvider%>#setAuthHeader
+     * @methodOf <%-: moduleName %>.<%-: commonResourceProvider%>
      * @param {string} header The header name to use, e.g. `X-Access-Token`
      * @description
      * Configure the REST transport to use a different header for sending
@@ -437,8 +439,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#getAuthHeader
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.<%-: commonResourceProvider%>#getAuthHeader
+     * @methodOf <%-: moduleName %>.<%-: commonResourceProvider%>
      * @description
      * Get the header name that is used for sending the authentication token.
      */
@@ -448,8 +450,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#setUrlBase
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.<%-: commonResourceProvider%>#setUrlBase
+     * @methodOf <%-: moduleName %>.<%-: commonResourceProvider%>
      * @param {string} url The URL to use, e.g. `/api` or `//example.com/api`.
      * @description
      * Change the URL of the REST API server. By default, the URL provided
@@ -462,8 +464,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
     /**
      * @ngdoc method
-     * @name <%-: moduleName %>.LoopBackResourceProvider#getUrlBase
-     * @methodOf <%-: moduleName %>.LoopBackResourceProvider
+     * @name <%-: moduleName %>.<%-: commonResourceProvider%>#getUrlBase
+     * @methodOf <%-: moduleName %>.<%-: commonResourceProvider%>
      * @description
      * Get the URL of the REST API server. The URL provided
      * to the code generator (`lb-ng` or `grunt-loopback-sdk-angular`) is used.
@@ -473,7 +475,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
     };
 
     this.$get = ['$resource', function($resource) {
-      var LoopBackResource = function(url, params, actions) {
+      var <%-: commonResource%> = function(url, params, actions) {
         var resource = $resource(url, params, actions);
 
         // Angular always calls POST on $save()
@@ -488,15 +490,15 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
         return resource;
       };
 
-      LoopBackResource.getUrlBase = function() {
+      <%-: commonResource%>.getUrlBase = function() {
         return urlBase;
       };
 
-      LoopBackResource.getAuthHeader = function() {
+      <%-: commonResource%>.getAuthHeader = function() {
         return authHeader;
       };
 
-      return LoopBackResource;
+      return <%-: commonResource%>;
     }];
   });
 <% } // end if (includeCommonModules)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "generate-loopback-core": "node ./apidocs/describe-builtin-models.js",
     "prepublish": "npm run generate-loopback-core",
-    "test": "node ./test.e2e/test-server.js node node_modules/karma/bin/karma start --single-run  --browsers PhantomJS",
+    "test": "mocha && node ./test.e2e/test-server.js node node_modules/karma/bin/karma start --single-run  --browsers PhantomJS",
     "lint": "eslint .",
     "posttest": "npm run generate-loopback-core && npm run lint"
   },

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -1208,10 +1208,12 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
           });
       });
 
-      it('defines the "Product" model as "lbServices.Product"', function() {
+      it('does not define "Product" model', function() {
         expect(function() {
           $injector.get('Product');
         }).to.throw(/Unknown provider/);
+      });
+      it('defines the "Product" model as "lbServices.Product"', function() {
         expect(function() {
           $injector.get('lbServices.Product');
         }).to.not.throw();
@@ -1241,12 +1243,54 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
           });
       });
 
-      it('defines the "Product" model as "lbServices.Product"', function() {
+      it('does not define "Product" model', function() {
         expect(function() {
           $injector.get('Product');
         }).to.throw(/Unknown provider/);
+      });
+      it('defines the "Product" model as "lbServices_Product"', function() {
         expect(function() {
           $injector.get('lbServices_Product');
+        }).to.not.throw();
+      });
+    });
+
+    describe('$resource generated with namespaceCommonModels:true and ' +
+      'namespaceDelimiter:_', function() {
+      var $injector;
+      before(function() {
+        return given.servicesForLoopBackApp(
+          {
+            models: {
+              Product: {
+                properties: {
+                  name: 'string',
+                  price: { type: 'number' },
+                },
+              },
+            },
+            name: 'lbServices',
+            namespaceCommonModels: true,
+            namespaceDelimiter: '_',
+          })
+          .then(function(createInjector) {
+            $injector = createInjector();
+          });
+      });
+
+      it('fails to find "Auth" common model', function() {
+        expect(function() {
+          $injector.get('Auth');
+        }).to.throw(/Unknown provider/);
+      });
+      it('fails to find "LoopBackAuth" common model', function() {
+        expect(function() {
+          $injector.get('LoopBackAuth');
+        }).to.throw(/Unknown provider/);
+      });
+      it('finds "lbServices_Auth" common model', function() {
+        expect(function() {
+          $injector.get('lbServices_Auth');
         }).to.not.throw();
       });
     });

--- a/test.e2e/test-server.js
+++ b/test.e2e/test-server.js
@@ -161,6 +161,7 @@ function generateService(generator, lbApp, apiUrl, opts) {
   if (opts.includeSchema !== undefined ||
       opts.includeCommonModules !== undefined ||
       opts.namespaceModels !== undefined ||
+      opts.namespaceCommonModels !== undefined ||
       opts.namespaceDelimiter !== undefined ||
       opts.modelsToIgnore !== undefined) {
     // the new options-based API

--- a/test/services.test.js
+++ b/test/services.test.js
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2014,2015. All Rights Reserved.
+// Node module: loopback-sdk-angular
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+var expect = require('chai').expect;
+var generateServices = require('..').services;
+var loopback = require('loopback');
+
+describe('services generator', function() {
+  it('rejects namespaceCommonModels:true with default namespaceDelimiter',
+  function() {
+    var app = loopback();
+    var options = {
+      namespaceCommonModels: true,
+    };
+
+    expect(function() { generateServices(app, options); })
+      .to.throw(/unsupported delimiter/i);
+  });
+});


### PR DESCRIPTION
This PR has code changes based on closed pull request #251.

Add namespacing to the core loopback models to allow multiple lb services to exist on the same client, pointing to APIs on different services.

You will need to set the delimiter in this case to something other than '.' to avoid invalid common names. The module name is used as the prefix. 

For example if the model name is Accounts and the delimiter is '_', then the generated core loopback models are: Accounts_Resource, Accounts_Auth, Accounts_ResourceProvider, Accounts_AuthRequestInterceptor.

See Issues #250 #251