### PR TITLE
Persist currentUserData to storage

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -314,7 +314,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 <% if (includeCommonModules) { %>
   module
   .factory('<%-: commonAuth%>', function() {
-    var props = ['accessTokenId', 'currentUserId', 'rememberMe'];
+    var props = ['accessTokenId', 'currentUserId', 'rememberMe', 'currentUserData'];
     var propsPrefix = '$LoopBack$';
 
     function <%-: commonAuth%>() {
@@ -322,7 +322,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       props.forEach(function(name) {
         self[name] = load(name);
       });
-      this.currentUserData = null;
+      // Don't clear currentUserData since we want to persist it.
+      //this.currentUserData = null;
     }
 
     <%-: commonAuth%>.prototype.save = function() {
@@ -360,6 +361,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
       try {
         var key = propsPrefix + name;
         if (value == null) value = '';
+        // currentUserData should be saved as stringified JSON
+        if(typeof value == 'object'){
+          value = JSON.stringify(value);
+        }
         storage[key] = value;
       } catch (err) {
         console.log('Cannot access local/session storage:', err);
@@ -368,7 +373,13 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 
     function load(name) {
       var key = propsPrefix + name;
-      return localStorage[key] || sessionStorage[key] || null;
+      var data = localStorage[key] || sessionStorage[key] || null;
+      // Try to parse JSON object.
+      try{
+        return JSON.parse(data);
+      } catch (e) {
+        return data
+      }
     }
   })
   .config(['$httpProvider', function($httpProvider) {


### PR DESCRIPTION
Stringify and Parse currentUserData object on save / load.

-- Use Case: When modifying the user instance on a hook, ie afterLogin, with one-time computation of data that we would like persisted via LoopBackAuth storage.