### PR TITLE
Create custom method generate endpoint without fk param

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -157,17 +157,22 @@ function describeModels(app, options) {
       return;
     }
 
+    var createMethod = c.methods.filter(function(method) {
+      return method.name === 'create';
+    });
+
+    if (createMethod && createMethod.length === 1) {
+      var createMany = Object.create(createMethod[0]);
+      createMany.name = 'createMany';
+      createMany.isReturningArray = function() { return true; };
+      c.methods.push(createMany);
+    }
+
     // The URL of prototype methods include sharedCtor parameters like ":id"
     // Because all $resource methods are static (non-prototype) in ngResource,
     // the sharedCtor parameters should be added to the parameters
     // of prototype methods.
     c.methods.forEach(function fixArgsOfPrototypeMethods(method, key) {
-      if (method.name == 'create') {
-        var createMany = Object.create(method);
-        createMany.name = 'createMany';
-        createMany.isReturningArray = function() { return true; };
-        c.methods.splice(key + 1, 0, createMany);
-      }
       var ctor = method.restClass.ctor;
       if (!ctor || method.sharedMethod.isStatic) return;
       method.accepts = ctor.accepts.concat(method.accepts);


### PR DESCRIPTION
### Description
Create custom method that extends endpoint generated by relation does not inherit **fk** param.

#### Related issues
- connect to #187 

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
