### PR TITLE
fix: Node.js 4.x support

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -1,3 +1,9 @@
+<%
+// Workaround for Node.js 4.x, where globals provided by EJS are not available
+// from within functions defined in the template (i.e. ngdocForMethod)
+global.moduleName = moduleName;
+global.helpers = helpers;
+-%>
 // CommonJS package manager support
 if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
   module.exports === exports) {


### PR DESCRIPTION
### Description

Fix the following error reported by our "describe-builtin-models"
script:

```
ReferenceError: ejs:526
    524|             /**
    525|              * @ngdoc method
 >> 526|              * @name <%- moduleName %>.<%- modelName %>#<%- methodName %>
    527|              * @methodOf <%- moduleName %>.<%- modelName %>
    528| <% if (action.deprecated) { -%>
    529|              * @deprecated <%- action.deprecated %>

moduleName is not defined
```

I noticed the problem when I saw red loopback-sdk-angular CI triggered from a loopback-datasource-juggler pull request.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- n/a

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- (n/a) New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
