### PR TITLE
Allow Request Cancelation

### DIFF
--- a/lib/services.template.ejs
+++ b/lib/services.template.ejs
@@ -131,6 +131,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' &&
 <% } -%>
               url: urlBase + <%- helpers.quotedString(helpers.getPropertyOfFirstEndpoint(action, 'fullPath'))  %>,
               method: <%- helpers.quotedString(helpers.getPropertyOfFirstEndpoint(action, 'verb')) %>,
+              cancellable: true,
             },
 <% }); // meta.methods.foreach -%>
 <% if (meta.isUser) { -%>

--- a/test.e2e/spec/services.spec.js
+++ b/test.e2e/spec/services.spec.js
@@ -345,6 +345,19 @@ define(['angular', 'given', 'util'], function(angular, given, util) {
         );
         return list.$promise;
       });
+      
+      it('has a $cancelRequest property', function() {
+        var list = MyModel.find(
+          function() {
+            
+          },
+          util.throwHttpError
+        );
+        
+        expect(list).to.have.own.property('$cancelRequest');
+        
+        return list.$promise;
+      });
 
       it('can create new resource', function() {
         var obj = MyModel.create({ name: 'new' }, function() {


### PR DESCRIPTION
### Description

Adds the ```cancellable: true``` field to all generated $request entities, allowing for request cancelation.

After adding this field means all returned resource objects have a function called ```$cancelRequest()``` which can be used to cancel a request in transit.

Previously, you were not able to cancel a request generated by lbservices. This is a common pattern that should be supported, but with the addition of this PR, it is.

Example:
```js
let request = false;

function findByName(name) {
  if (request) {
    request.$cancelRequest();
  }
  request = Users.find({
    filter: {
      where: { name },
    }
  });
  return request.$promise;
}

...
// Then Somewhere in your logic, fire 2 requests
findByName('Thomas')
  .then((user) => $scope.user = user);

// The previous request gets canceled, allowing this one to resolve
findByName('Dave')
  .then((user) => $scope.user = user);
```

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
